### PR TITLE
fix(auth): restore single-step login — remove LoginSchema refine()

### DIFF
--- a/apps/api/src/modules/auth/auth.routes.ts
+++ b/apps/api/src/modules/auth/auth.routes.ts
@@ -85,10 +85,7 @@ const LoginSchema = z.object({
   password: z.string().min(1),
   tenantId: z.string().uuid().optional(),
   tenantSlug: z.string().min(1).optional(),
-}).refine(
-  (d) => d.tenantId !== undefined || d.tenantSlug !== undefined,
-  { message: "Either tenantId or tenantSlug must be provided" },
-);
+});
 
 const PlatformLoginSchema = z.object({
   email: z.string().email(),

--- a/apps/api/src/modules/users/users.rls.test.ts
+++ b/apps/api/src/modules/users/users.rls.test.ts
@@ -28,11 +28,9 @@ describeIf("RLS isolation — platform.users (integration)", () => {
   let tenantBId: string;
 
   beforeAll(async () => {
-    // Ensure amis_app has access to the platform schema tables
-    await adminPool.query(
-      `GRANT USAGE ON SCHEMA platform TO amis_app;
-       GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA platform TO amis_app;`,
-    );
+    // Note: amis_app grants on platform schema are handled by migration 064.
+    // Do NOT re-issue GRANT here — concurrent test files cause "tuple
+    // concurrently updated" on pg system catalogs when grants run in parallel.
 
     // Create two isolated test tenants
     const resA = await adminPool.query<{ id: string }>(

--- a/apps/api/src/tests/auth/auth.test.ts
+++ b/apps/api/src/tests/auth/auth.test.ts
@@ -181,13 +181,13 @@ describeIf("Auth endpoints (integration)", () => {
       expect(res.json().message).toBe("Invalid credentials");
     });
 
-    it("returns 400 when tenantId is missing", async () => {
+    it("single-step login (no tenantId) resolves tenant from email → 200", async () => {
       const res = await app.inject({
         method: "POST",
         url: "/auth/login",
         payload: { email: VALID_EMAIL, password: VALID_PASSWORD },
       });
-      expect(res.statusCode).toBe(400);
+      expect(res.statusCode).toBe(200);
     });
 
     it("returns 400 when email is missing", async () => {


### PR DESCRIPTION
## Problem

Staging login was returning **400** for all frontend login attempts.

**Root cause**: A `.refine()` added to `LoginSchema` in commit `e25e2e4` required either `tenantId` or `tenantSlug` to be present. But the frontend sends only `{ email, password }` when no `?org=` query param is in the URL, which is the default for most users.

## What was changed

The API handler intentionally supports **single-step login**: if neither `tenantId` nor `tenantSlug` is provided, it resolves the tenant by looking up which tenant the email belongs to:
- 0 tenants → 401
- 1 tenant → proceeds with login → 200
- >1 tenants → 409 with list of slugs (user picks one)

The `.refine()` blocked this at schema validation before the handler logic could run.

## Fix

- **`auth.routes.ts`**: Removed `.refine()` from `LoginSchema` — `tenantId` and `tenantSlug` remain optional (as intended)
- **`auth.test.ts`**: Updated test that was incorrectly asserting 400 → now asserts 200 for single-step login with `admin@tenant-a.test` (seeded in exactly one tenant)

Note: `ForgotPasswordSchema` keeps its `.refine()` — password reset legitimately requires a tenant identifier.