### PR TITLE
fix(ui): improve login page footer text contrast

### DIFF
--- a/apps/web/src/auth/LoginPage.tsx
+++ b/apps/web/src/auth/LoginPage.tsx
@@ -447,11 +447,11 @@ export function LoginPage() {
           )}
         </div>
 
-        <p style={{ position: "fixed", bottom: 16, left: 0, right: 0, textAlign: "center", fontSize: 11, color: "#d1d5db", pointerEvents: "none" }}>
+        <p style={{ position: "fixed", bottom: 16, left: 0, right: 0, textAlign: "center", fontSize: 11, color: "#6b7280", pointerEvents: "none" }}>
           {APP_NAME} · Academic Management Information System
         </p>
         <p style={{ position: "fixed", bottom: 36, left: 0, right: 0, textAlign: "center", fontSize: 11 }}>
-          <Link to="/platform-login" style={{ color: "#9ca3af", textDecoration: "none" }}>
+          <Link to="/platform-login" style={{ color: "#374151", textDecoration: "none", fontWeight: 500 }}>
             Platform Administrator?
           </Link>
         </p>


### PR DESCRIPTION
## Problem
Two labels at the bottom of the login page were barely readable:

| Element | Old color | Background | Contrast ratio |
|---|---|---|---|
| `AMIS · Academic Management Information System` | `#d1d5db` | `#f8fafc` | ~2.5:1 ❌ |
| `Platform Administrator?` link | `#9ca3af` | `#f8fafc` | ~3.0:1 ❌ |

Both fail WCAG AA minimum (4.5:1 for small text).

## Fix
- Footer text: `#d1d5db` → `#6b7280` (~4.6:1 ✅)
- Link: `#9ca3af` → `#374151` (~8.6:1 ✅) + `fontWeight: 500` for added legibility