### PR TITLE
feat(fees): fix fee-collection report table + term_id filter (#84)

### DIFF
--- a/apps/api/src/modules/fees/fees.test.ts
+++ b/apps/api/src/modules/fees/fees.test.ts
@@ -247,6 +247,25 @@ describe("POST /fees/entry", () => {
     expect(res.statusCode).toBe(201);
     expect(res.json()).toMatchObject({ payment: { reference: "REF-001" } });
   });
+
+  it("returns 201 and stores term_id and academic_year_id", async () => {
+    const TERM_ID = "dd000000-0000-0000-0000-000000000001";
+    const AY_ID = "ee000000-0000-0000-0000-000000000001";
+    const paymentWithTerm = { ...fakePayment, term_id: TERM_ID, academic_year_id: AY_ID };
+    mockWithTenant.mockResolvedValueOnce({ payment: paymentWithTerm } as never);
+    const app = buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/fees/entry",
+      headers: financeHeaders,
+      payload: { ...validEntryBody, term_id: TERM_ID, academic_year_id: AY_ID },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(res.json().payment).toMatchObject({
+      term_id: TERM_ID,
+      academic_year_id: AY_ID,
+    });
+  });
 });
 
 // ------------------------------------------------------------------ POST /fees/import

--- a/apps/api/src/modules/reports/reports.routes.ts
+++ b/apps/api/src/modules/reports/reports.routes.ts
@@ -693,26 +693,31 @@ export async function reportsRoutes(app: FastifyInstance) {
         return reply.status(400).send({ error: "x-tenant-id header required" });
 
       const q = req.query as Record<string, string>;
-      const term = q.term ?? null;
+      const term_id = q.term_id ?? null;
+      const academic_year_id = q.academic_year_id ?? null;
       const from = q.from ?? null;
       const to = q.to ?? null;
       const programme = q.programme ?? null;
 
       const result = await withTenant(tid, async (client) => {
-        const conditions: string[] = ["fp.tenant_id = $1"];
+        const conditions: string[] = ["p.tenant_id = $1"];
         const params: unknown[] = [tid];
 
-        if (term) {
-          params.push(term);
-          conditions.push(`fp.term = $${params.length}`);
+        if (term_id) {
+          params.push(term_id);
+          conditions.push(`p.term_id = $${params.length}`);
+        }
+        if (academic_year_id) {
+          params.push(academic_year_id);
+          conditions.push(`p.academic_year_id = $${params.length}`);
         }
         if (from) {
           params.push(from);
-          conditions.push(`fp.payment_date >= $${params.length}`);
+          conditions.push(`p.paid_at >= $${params.length}`);
         }
         if (to) {
           params.push(to);
-          conditions.push(`fp.payment_date <= $${params.length}`);
+          conditions.push(`p.paid_at <= $${params.length}`);
         }
         if (programme) {
           params.push(programme);
@@ -721,35 +726,41 @@ export async function reportsRoutes(app: FastifyInstance) {
 
         const { rows: payments } = await client.query(
           `SELECT
-             fp.id,
-             fp.student_id,
+             p.id,
+             p.student_id,
              s.admission_number,
              s.first_name,
              s.last_name,
              s.programme,
-             fp.amount,
-             fp.payment_method,
-             fp.payment_date,
-             fp.term,
-             fp.reference_number
-           FROM app.fee_payments fp
-           LEFT JOIN app.students s ON s.id = fp.student_id
+             p.amount,
+             p.currency,
+             p.reference,
+             p.paid_at,
+             p.source,
+             p.term_id,
+             t.name AS term_name,
+             p.academic_year_id
+           FROM app.payments p
+           LEFT JOIN app.students s ON s.id = p.student_id
+           LEFT JOIN app.terms t ON t.id = p.term_id
            WHERE ${conditions.join(" AND ")}
-           ORDER BY fp.payment_date DESC`,
+           ORDER BY p.paid_at DESC`,
           params,
         );
 
         const { rows: summary } = await client.query(
           `SELECT
-             fp.term,
+             p.term_id,
+             t.name AS term_name,
              s.programme,
              COUNT(*) AS payment_count,
-             SUM(fp.amount) AS total_collected
-           FROM app.fee_payments fp
-           LEFT JOIN app.students s ON s.id = fp.student_id
+             SUM(p.amount) AS total_collected
+           FROM app.payments p
+           LEFT JOIN app.students s ON s.id = p.student_id
+           LEFT JOIN app.terms t ON t.id = p.term_id
            WHERE ${conditions.join(" AND ")}
-           GROUP BY fp.term, s.programme
-           ORDER BY fp.term, s.programme`,
+           GROUP BY p.term_id, t.name, s.programme
+           ORDER BY t.name, s.programme`,
           params,
         );
 
@@ -761,13 +772,14 @@ export async function reportsRoutes(app: FastifyInstance) {
         return {
           payments,
           by_programme_term: summary.map((r: Record<string, string>) => ({
-            term: r.term,
+            term_id: r.term_id,
+            term_name: r.term_name,
             programme: r.programme,
             payment_count: Number(r.payment_count),
             total_collected: Number(r.total_collected),
           })),
           grand_total: totals,
-          filters: { term, from, to, programme },
+          filters: { term_id, academic_year_id, from, to, programme },
         };
       });
 


### PR DESCRIPTION
## Summary
Fixes issue #84 — payments need term_id support.

### Changes
- **`GET /reports/fee-collection`**: was querying non-existent `app.fee_payments` table. Fixed to use `app.payments` with correct column names (`paid_at`, `reference`). Replaced free-text `term` filter with proper `term_id` UUID FK filter. Added `academic_year_id` filter. Joins `app.terms` for `term_name` in response.
- **`fees.test.ts`**: adds test verifying `POST /fees/entry` accepts and returns `term_id` + `academic_year_id`.

### Already complete (no changes needed)
- Migration `20260429000053_payments_term_id.sql` — adds `term_id` + `academic_year_id` to `app.payments`
- `FeeEntrySchema` — already includes both fields as optional UUIDs
- `POST /fees/entry` route — already stores both fields in the INSERT

### Test results
40/40 tests pass in `fees.test.ts`

Closes #84