### PR TITLE
feat(term-reg): wire FK UUIDs on term_registrations (#85)

### DIFF
--- a/apps/api/src/modules/term-registrations/term-registrations.routes.ts
+++ b/apps/api/src/modules/term-registrations/term-registrations.routes.ts
@@ -148,7 +148,7 @@ export async function termRegistrationsRoutes(app: FastifyInstance) {
       if (!parsed.success)
         return reply.status(422).send({ error: parsed.error.flatten() });
 
-      const { student_id, academic_year, term, current_state, page, limit } =
+      const { student_id, academic_year, term, academic_year_id, term_id, current_state, page, limit } =
         parsed.data;
       const offset = (page - 1) * limit;
 
@@ -160,11 +160,17 @@ export async function termRegistrationsRoutes(app: FastifyInstance) {
           params.push(student_id);
           conditions.push(`r.student_id = $${params.length}`);
         }
-        if (academic_year) {
+        if (academic_year_id) {
+          params.push(academic_year_id);
+          conditions.push(`r.academic_year_id = $${params.length}`);
+        } else if (academic_year) {
           params.push(academic_year);
           conditions.push(`r.academic_year = $${params.length}`);
         }
-        if (term) {
+        if (term_id) {
+          params.push(term_id);
+          conditions.push(`r.term_id = $${params.length}`);
+        } else if (term) {
           params.push(term);
           conditions.push(`r.term = $${params.length}`);
         }
@@ -373,14 +379,26 @@ export async function termRegistrationsRoutes(app: FastifyInstance) {
           [academic_year, term],
         );
 
+        // Resolve FK IDs once for all students in the batch
+        const { rows: promoteAyRows } = await client.query<{ id: string }>(
+          `SELECT id FROM app.academic_years WHERE tenant_id = $1 AND name = $2 LIMIT 1`,
+          [tid, academic_year],
+        );
+        const { rows: promoteTRows } = await client.query<{ id: string }>(
+          `SELECT id FROM app.terms WHERE tenant_id = $1 AND name = $2 LIMIT 1`,
+          [tid, term],
+        );
+        const promoteAcademicYearId = promoteAyRows[0]?.id ?? null;
+        const promoteTermId = promoteTRows[0]?.id ?? null;
+
         let created = 0;
         for (const { id: student_id } of students) {
           const { rows: regRows } = await client.query(
             `INSERT INTO app.term_registrations
-               (tenant_id, student_id, academic_year, term, extension, created_by)
-             VALUES ($1, $2, $3, $4, '{}', $5)
+               (tenant_id, student_id, academic_year, term, academic_year_id, term_id, extension, created_by)
+             VALUES ($1, $2, $3, $4, $5, $6, '{}', $7)
              RETURNING id`,
-            [tid, student_id, academic_year, term, actorUserId],
+            [tid, student_id, academic_year, term, promoteAcademicYearId, promoteTermId, actorUserId],
           );
           const regId = regRows[0].id;
 

--- a/apps/api/src/modules/term-registrations/term-registrations.schema.ts
+++ b/apps/api/src/modules/term-registrations/term-registrations.schema.ts
@@ -22,6 +22,8 @@ export const TermRegistrationsQuerySchema = z.object({
   student_id: z.string().uuid().optional(),
   academic_year: z.string().optional(),
   term: z.string().optional(),
+  academic_year_id: z.string().uuid().optional(),
+  term_id: z.string().uuid().optional(),
   current_state: z.string().optional(),
   page: z.coerce.number().int().min(1).default(1),
   limit: z.coerce.number().int().min(1).max(100).default(20),

--- a/apps/api/src/modules/term-registrations/term-registrations.test.ts
+++ b/apps/api/src/modules/term-registrations/term-registrations.test.ts
@@ -243,6 +243,29 @@ describe("GET /term-registrations", () => {
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual([]);
   });
+
+  it("returns 200 when filtering by term_id UUID (#85)", async () => {
+    const TERM_ID = "aa000000-0000-0000-0000-000000000001";
+    mockWithTenant.mockResolvedValueOnce({ rows: [fakeRegistration] } as never);
+    const app = buildApp();
+    const res = await app.inject({
+      method: "GET",
+      url: `/term-registrations?term_id=${TERM_ID}`,
+      headers,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toHaveLength(1);
+  });
+
+  it("returns 422 when term_id filter is not a valid UUID (#85)", async () => {
+    const app = buildApp();
+    const res = await app.inject({
+      method: "GET",
+      url: "/term-registrations?term_id=not-a-uuid",
+      headers,
+    });
+    expect(res.statusCode).toBe(422);
+  });
 });
 
 // ------------------------------------------------------------------ GET /term-registrations/:id


### PR DESCRIPTION
## Summary
Fixes issue #85 — term registrations use free-text labels, not FK references.

### Changes
- **`POST /term-registrations/promote`**: was not storing `academic_year_id`/`term_id` FK columns. Fixed to resolve FK IDs by name lookup before inserting.
- **`GET /term-registrations`**: added `academic_year_id` and `term_id` UUID query params. UUID FK filters take precedence over text label filters when both are supplied.
- **`TermRegistrationsQuerySchema`**: added `academic_year_id` and `term_id` as optional UUID fields.
- **`term-registrations.test.ts`**: added tests for UUID FK filter (200 on valid UUID, 422 on invalid UUID).

### Already complete (no changes needed)
- Migration `20260429000054_term_registrations_fk.sql` — adds `academic_year_id`/`term_id` FK columns with back-fill
- `POST /term-registrations` and `POST /term-registrations/bulk` — already stored FK IDs

### Test results
20/20 tests pass in `term-registrations.test.ts`

Closes #85