### PR TITLE
feat: demo-feedback recommendations (#146-#151)

### DIFF
--- a/.env.staging.example
+++ b/.env.staging.example
@@ -21,3 +21,30 @@ VITE_API_URL=https://api.pre.amis.institute
 # Shows a visible "STAGING" banner across the top of the UI.
 # Leave unset (or remove) for production builds.
 VITE_APP_ENV=staging
+
+# ── Transactional email (Issue #148) ──────────────────────────────────────────
+# AMIS supports two transports; configure ONE (or leave blank to disable email).
+#
+# Option A — Resend (preferred for cloud SaaS deployments)
+#   Used by lib/email.ts (welcome, password-reset emails).
+#   Sign up at https://resend.com, add & verify amis.institute as a sending
+#   domain, then paste the API key here.
+RESEND_API_KEY=
+RESEND_FROM=AMIS <noreply@amis.institute>
+#
+# Option B — SMTP (used by lib/mailer.ts → notify.ts)
+#   Required for VTI-hosted / offline / on-prem deployments that cannot
+#   reach Resend. Configure SPF, DKIM, and DMARC records on the sending
+#   domain to avoid deliverability problems (see DEPLOY.md).
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USER=
+SMTP_PASS=
+SMTP_FROM=AMIS <noreply@amis.local>
+SMTP_SECURE=false
+
+# ── Redis (Issue #149) ────────────────────────────────────────────────────────
+# REDIS_URL is hard-coded in docker-compose.staging.yml to the internal `redis`
+# service. Override here ONLY if pointing at an external Redis (e.g. managed
+# Redis on Azure/AWS). Leave empty to use the default.
+# REDIS_URL=redis://redis:6379

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -276,6 +276,61 @@ Or use the AMIS platform admin at `https://amis.institute` to create the KTI ten
 
 ---
 
+## Part 6b — Transactional Email (SMTP / Resend)
+
+AMIS sends transactional email for: password reset, account-setup welcome,
+and outbound notifications. Two transports are supported; configure **one**.
+
+### Option A — Resend (recommended for cloud SaaS)
+
+1. Sign up at <https://resend.com> and add `amis.institute` as a sending domain.
+2. Add the DNS records Resend gives you to the `amis.institute` zone:
+   - **SPF**:  `v=spf1 include:_spf.resend.com -all`
+   - **DKIM**: `<resend>._domainkey  CNAME  <selector>.dkim.resend.com`
+   - **DMARC**: `_dmarc  TXT  "v=DMARC1; p=quarantine; rua=mailto:postmaster@amis.institute"`
+3. After Resend verifies the domain, copy the API key into `.env.staging` /
+   `.env.prod`:
+   ```env
+   RESEND_API_KEY=re_xxxxxxxxxxxxxxxxxxxxxx
+   RESEND_FROM=AMIS <noreply@amis.institute>
+   ```
+4. Restart the api container:
+   ```bash
+   docker compose -f docker-compose.staging.yml --project-name amis-staging up -d --no-deps api
+   ```
+5. Verify with `curl -s https://api.pre.amis.institute/health` — `checks.email`
+   should now be `configured`.
+
+### Option B — SMTP (used for VTI-hosted / on-prem deployments)
+
+If the deployment cannot reach Resend (offline VTI, sovereign-cloud requirement),
+configure a self-managed SMTP relay (Postfix, Amazon SES, MailerSend, etc.):
+
+```env
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=postmaster@amis.local
+SMTP_PASS=…
+SMTP_FROM=AMIS <noreply@amis.local>
+SMTP_SECURE=false   # true → implicit TLS on 465
+```
+
+The same SPF / DKIM / DMARC guidance applies — publish the records on
+whichever domain you set in `SMTP_FROM`, otherwise mail will land in spam.
+
+### Verifying delivery
+
+- Trigger a password reset for a test account and watch the api logs:
+  ```bash
+  docker compose -f docker-compose.staging.yml --project-name amis-staging logs -f api | grep -E "mailer|email"
+  ```
+- A line containing `Sent "Password Reset Request"` (SMTP) or absence of a
+  `RESEND_API_KEY not set` warning (Resend) confirms the transport is wired.
+- If neither is configured, email is silently skipped and AMIS continues to
+  work; the api logs the would-be recipient and subject.
+
+---
+
 ## Part 7 — UTC Kyema On-Premises (Offline) Deployment
 
 Uganda Technical College — Kyema operates on a local LAN with no guaranteed internet access.

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -6,6 +6,7 @@ import multipart from "@fastify/multipart";
 import fastifyStatic from "@fastify/static";
 import { resolve } from "path";
 import { pool } from "./db/pool.js";
+import { isEmailConfigured } from "./lib/email.js";
 import { studentsRoutes } from "./modules/students/students.routes.js";
 import { configRoutes } from "./modules/config/config.routes.js";
 import { workflowRoutes } from "./modules/workflow/workflow.routes.js";
@@ -113,13 +114,23 @@ export function buildApp() {
   });
 
   app.get("/health", async (_req, _reply) => {
+    const checks: Record<string, string> = {};
+    let dbOk = true;
     try {
       await pool.query("SELECT 1");
-      return { status: "ok" };
+      checks.database = "ok";
     } catch {
-      _reply.status(503);
-      return { status: "error", message: "database unreachable" };
+      dbOk = false;
+      checks.database = "error";
     }
+    checks.email = isEmailConfigured() ? "configured" : "not_configured";
+    checks.redis = process.env.REDIS_URL ? "configured" : "not_configured";
+
+    if (!dbOk) {
+      _reply.status(503);
+      return { status: "error", message: "database unreachable", checks };
+    }
+    return { status: "ok", checks };
   });
 
   app.register(authRoutes);

--- a/apps/api/src/lib/email.ts
+++ b/apps/api/src/lib/email.ts
@@ -1,15 +1,16 @@
 import { Resend } from "resend";
 
-const FROM = "AMIS <noreply@amis.institute>";
+const FROM = process.env.RESEND_FROM ?? "AMIS <noreply@amis.institute>";
 
-function getResend(): Resend {
+function getResend(): Resend | null {
   const apiKey = process.env.RESEND_API_KEY;
-  if (!apiKey) {
-    throw new Error(
-      "[email] RESEND_API_KEY environment variable is required. Add it to .env before starting the server.",
-    );
-  }
+  if (!apiKey) return null;
   return new Resend(apiKey);
+}
+
+/** True when transactional email transport is configured. */
+export function isEmailConfigured(): boolean {
+  return Boolean(process.env.RESEND_API_KEY);
 }
 
 interface SendMailOptions {
@@ -21,6 +22,16 @@ interface SendMailOptions {
 
 export async function sendMail(options: SendMailOptions): Promise<void> {
   const resend = getResend();
+  if (!resend) {
+    // Graceful no-op when email infrastructure isn't configured (e.g.
+    // local dev, staging before SMTP/Resend secrets are provisioned).
+    // The caller's flow (password reset, welcome) still completes; the
+    // operator sees the would-be email in the log.
+    console.warn(
+      `[email] RESEND_API_KEY not set — skipping email to ${options.to} (subject: "${options.subject}")`,
+    );
+    return;
+  }
   const { error } = await resend.emails.send({
     from: FROM,
     to: options.to,
@@ -29,7 +40,9 @@ export async function sendMail(options: SendMailOptions): Promise<void> {
     text: options.text,
   });
   if (error) {
-    throw new Error(`[email] Resend error: ${error.message}`);
+    // Log but don't throw — a transient email outage shouldn't block
+    // the user-visible request (e.g. forgot-password returning 200).
+    console.error(`[email] Resend error sending "${options.subject}" to ${options.to}:`, error.message);
   }
 }
 

--- a/apps/api/src/modules/students/students.test.ts
+++ b/apps/api/src/modules/students/students.test.ts
@@ -14,7 +14,7 @@ describe("GET /health", () => {
     const app = buildApp();
     const res = await app.inject({ method: "GET", url: "/health" });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toEqual({ status: "ok" });
+    expect(res.json()).toMatchObject({ status: "ok" });
   });
 });
 

--- a/apps/web/src/auth/LoginPage.tsx
+++ b/apps/web/src/auth/LoginPage.tsx
@@ -126,7 +126,7 @@ export function LoginPage() {
         const slugs = body?.tenantSlugs ?? [];
         setAvailableSlugs(slugs);
         setShowSlug(true);
-        setError("Your email is registered at multiple institutions. Enter your institution code below.");
+        setError("Your email is registered at more than one institution. Pick the right one below or enter your institution code (e.g. \"kti\", \"greenfield-vti\").");
       } else if (err instanceof ApiError && err.status === 401) {
         setError("Invalid email or password.");
       } else {
@@ -402,7 +402,7 @@ export function LoginPage() {
                   onChange={setSlugInput}
                   placeholder="e.g. kti"
                   autoComplete="off"
-                  hint="Your institution code was provided at setup."
+                  hint="Short code your institute uses in the AMIS URL (e.g. kti, greenfield-vti). Ask your administrator if unsure."
                 />
                 {availableSlugs.length > 0 && (
                   <div style={{ marginTop: 8, display: "flex", flexWrap: "wrap", gap: 6 }}>

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -27,6 +27,18 @@ services:
       retries: 5
     restart: unless-stopped
 
+  redis:
+    image: redis:7-alpine
+    # No host port published — internal only
+    volumes:
+      - redis_staging:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+
   api:
     build:
       context: .
@@ -37,6 +49,18 @@ services:
       DATABASE_URL: postgres://${POSTGRES_USER:-amis}:${POSTGRES_PASSWORD:?required}@db:5432/${POSTGRES_DB:-amis_staging}
       JWT_SECRET: ${JWT_SECRET:?required}
       CORS_ORIGIN: ${CORS_ORIGIN:?required}
+      # BullMQ outbox queue (Issue #149 — offline/PWA support)
+      REDIS_URL: redis://redis:6379
+      # Transactional email — set in .env.staging (Issue #148)
+      # Either Resend (default) or SMTP via mailer.ts
+      RESEND_API_KEY: ${RESEND_API_KEY:-}
+      RESEND_FROM: ${RESEND_FROM:-AMIS <noreply@amis.institute>}
+      SMTP_HOST: ${SMTP_HOST:-}
+      SMTP_PORT: ${SMTP_PORT:-587}
+      SMTP_USER: ${SMTP_USER:-}
+      SMTP_PASS: ${SMTP_PASS:-}
+      SMTP_FROM: ${SMTP_FROM:-AMIS <noreply@amis.local>}
+      SMTP_SECURE: ${SMTP_SECURE:-false}
     # Published on 3002 so native Nginx can proxy_pass to localhost:3002
     ports:
       - "127.0.0.1:3002:3000"
@@ -44,6 +68,8 @@ services:
       - uploads_staging:/app/apps/api/uploads
     depends_on:
       db:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:3000/health || exit 1"]
@@ -82,3 +108,4 @@ services:
 volumes:
   pgdata_staging:
   uploads_staging:
+  redis_staging:

--- a/docs/ADMIN-GOVERNANCE.md
+++ b/docs/ADMIN-GOVERNANCE.md
@@ -1,0 +1,134 @@
+# AMIS — Administration & Governance Model
+
+> Companion to [ADR-0001](./adr/0001-deployment-model.md).
+> Addresses Issue [#150](https://github.com/3bsolutionsltd/amis-multi-tenant/issues/150)
+> raised in the May 2026 stakeholder demo.
+
+This document defines who administers what in AMIS, how support is delivered,
+and the SLAs that VTIs (Vocational Training Institutes) can expect from 3B
+Solutions Ltd as the AMIS operator.
+
+## 1. Roles
+
+AMIS has two administrative layers; users hold roles at exactly one layer.
+
+### 1.1 Platform administrator (3B Solutions)
+
+- Role name in DB: `platform_admin`
+- Holds the keys to **all** tenants.
+- Responsible for:
+  - Provisioning new VTI tenants (`scripts/provision-tenant.js`).
+  - Patches, dependency upgrades, CVE response.
+  - Backups, disaster recovery, monitoring, on-call.
+  - UVTAB-wide configuration changes (national grading scale revisions,
+    new programme codes, etc.).
+- Day-to-day staff: 3B Solutions support engineers under written NDA.
+
+### 1.2 Institute administrator (VTI)
+
+- Role name in DB: `admin`
+- Scope: **single tenant only** (enforced by Postgres Row-Level Security).
+- Responsible for:
+  - Adding/removing staff users, assigning role-bound permissions.
+  - Configuring institute-specific calendar, fee structure, programmes.
+  - Approving admissions, releasing marks, certifying graduations.
+  - Front-line support to their own staff and students.
+- Cannot:
+  - See or touch any other tenant's data.
+  - Modify the schema, deploy code, or rotate the JWT secret.
+
+### 1.3 Support tiers
+
+| Tier  | Owner          | Handles                                                  |
+| :---: | -------------- | -------------------------------------------------------- |
+|   1   | VTI admin      | Staff / student questions, day-to-day data entry issues  |
+|   2   | 3B Helpdesk    | Errors, login problems, data export requests             |
+|   3   | 3B Engineering | Bugs, data corrections, security incidents               |
+
+## 2. Provisioning a new VTI
+
+1. VTI signs the **Service Agreement** (cloud) or the **Self-Hosting Addendum**
+   (on-prem, see ADR-0001).
+2. 3B platform admin runs:
+   ```bash
+   DATABASE_URL=… node scripts/provision-tenant.js \
+     --slug greenfield-vti \
+     --name "Greenfield VTI" \
+     --email principal@greenfield.ac.ug \
+     --first Jane --last Mukasa
+   ```
+3. The script writes `provisioned-greenfield-vti.txt` (mode 0600) with
+   credentials. 3B delivers it to the institute via a sealed channel
+   (encrypted PDF, password sent on a separate channel).
+4. The VTI admin signs in at `https://amis.institute/login`, changes the
+   password, and invites additional staff.
+
+## 3. SLAs (cloud-hosted tenants)
+
+| Item                          | Target                            |
+| ----------------------------- | --------------------------------- |
+| Uptime (rolling 90 d)         | 99.5 %                            |
+| Planned-maintenance window    | Sundays 02:00–05:00 EAT (UTC+3)   |
+| Notification of maintenance   | ≥ 5 business days in advance      |
+| Backup frequency              | Daily full + 6-hourly WAL         |
+| Backup retention              | 30 days                           |
+| RPO (recovery point objective)| 6 hours                           |
+| RTO (recovery time objective) | 8 hours                           |
+| Tier-3 response (Sev-1)       | 4 hours business / 8 h after-hours|
+| Tier-3 response (Sev-2)       | 1 business day                    |
+| Tier-3 response (Sev-3/4)     | 5 business days                   |
+
+Self-hosted tenants (ADR-0001 Option B) operate their own backups and uptime;
+3B supports patches and bug fixes only, on the cadence in their support
+contract (default: quarterly).
+
+## 4. Release cadence
+
+- **Patches & security fixes:** rolling, deployed to staging
+  (`pre.amis.institute`) first, then production after at least 24 h of
+  smoke-testing. Critical CVEs override this gating.
+- **Feature releases:** monthly, batched into a release notes post.
+- **Schema migrations:** delivered via `dbmate`; staging is always one
+  release ahead of prod so VTIs see new fields on staging first.
+
+## 5. Data ownership & data-protection
+
+- The VTI is the **data controller** for its tenant's records. 3B Solutions
+  is the **data processor**. A DPA (Data Processing Agreement) is signed
+  per tenant; the template lives in `docs/legal/` (TBD).
+- Personal data is processed only for the purposes set out in the DPA.
+- On termination, the VTI receives a full SQL + file export within 30 days;
+  3B retains an encrypted backup for legal-hold purposes (1 year) then
+  destroys it.
+- Sub-processors (currently: hosting provider, Resend for email, Sentry for
+  errors) are listed in the DPA and changed only with 30 days notice.
+
+## 6. Change-management & approvals
+
+- All schema changes go through **PR review** in
+  `3bsolutionsltd/amis-multi-tenant`. Branch protection requires:
+  - 1 approving review
+  - CI `test` job green
+  - No stale reviews
+- Production deploys require sign-off by a second 3B engineer (4-eyes
+  principle). Audit log is the GitHub PR + the deploy log on the VPS.
+- VTI admins are notified of UVTAB-wide config changes (national grading
+  scale, programme codes) at least 14 days before they take effect.
+
+## 7. Incident response
+
+- Sev-1 (data breach, total outage, data loss) — 3B on-call paged within
+  15 minutes; affected VTIs informed within 1 hour; UVTAB informed within
+  4 hours.
+- Sev-2 (degraded performance, partial outage, isolated user-facing bug) —
+  next business hour.
+- Post-incident review (PIR) shared with affected VTIs within 5 business
+  days for Sev-1 and within 10 days for Sev-2.
+
+## 8. Open items
+
+These are tracked separately and will be folded in once decided:
+
+- DPA template language (legal review pending).
+- UVTAB approval & accreditation status (in progress).
+- Pricing model for self-hosted support tier (ADR-0001 Option B).

--- a/docs/adr/0001-deployment-model.md
+++ b/docs/adr/0001-deployment-model.md
@@ -1,0 +1,114 @@
+# ADR-0001 — Deployment Model: Multi-Tenant Cloud vs VTI-Hosted Single-Tenant
+
+- **Status:** Proposed
+- **Date:** 2026-05-12
+- **Deciders:** AMIS Steering Group (3B Solutions Ltd, UVTAB, pilot VTI principals)
+- **Related issues:** [#151](https://github.com/3bsolutionsltd/amis-multi-tenant/issues/151), [#149](https://github.com/3bsolutionsltd/amis-multi-tenant/issues/149), [#150](https://github.com/3bsolutionsltd/amis-multi-tenant/issues/150)
+
+## Context
+
+After the first stakeholder demo (May 2026) two deployment topologies were
+proposed for the Academic Management Information System (AMIS):
+
+1. **Multi-tenant cloud (SaaS).** One AMIS instance hosted by 3B Solutions
+   on a public cloud (Azure / AWS / Hetzner). Each VTI (Vocational Training
+   Institute) is a tenant inside that instance, isolated by `tenant_id`
+   and Postgres Row-Level Security.
+2. **VTI-hosted single-tenant.** Each VTI runs its own AMIS instance, either
+   on an on-prem server or a small VPS that the VTI owns. The codebase is
+   the same; only the tenant table contains one row.
+
+Both topologies are supported by the current code (the offline / PWA work in
+Issue #149 explicitly enables single-tenant on intermittent connectivity).
+The question is which to **recommend as the default** and which to support
+as a documented exception.
+
+## Decision Drivers
+
+| #   | Driver                                  | Why it matters                                                       |
+| --- | --------------------------------------- | -------------------------------------------------------------------- |
+| D1  | Data sovereignty & DPA compliance       | Uganda Data Protection Act 2019; student PII; UNEB exam data         |
+| D2  | Operational burden on the VTI           | VTIs have limited IT capacity; downtime hurts learners               |
+| D3  | Total cost of ownership                 | VTIs are publicly funded; budgets are tight                          |
+| D4  | Patch & upgrade cadence                 | UVTAB regulatory changes require quick rollout                       |
+| D5  | Offline/intermittent-connectivity       | Many VTIs have unreliable internet; some have none                   |
+| D6  | Security posture                        | Centralised hardening vs distributed unknown                         |
+| D7  | UVTAB / inter-institute reporting       | National statistics require data aggregation                         |
+| D8  | Vendor lock-in / exit                   | VTI must be able to leave with its data                              |
+
+## Options Considered
+
+### Option A — Multi-tenant cloud (SaaS) [recommended default]
+
+3B Solutions runs `pre.amis.institute` (staging) and `amis.institute`
+(prod). Each VTI logs in via its **institution code** (tenant slug) and is
+isolated by RLS. Backups, patches, monitoring, and CVE response are
+centralised.
+
+### Option B — VTI-hosted single-tenant
+
+Each VTI receives a Docker image (or offline bundle) and runs AMIS on a
+local server. The VTI is responsible for backups, patching, and TLS.
+Updates are delivered as quarterly bundles.
+
+### Option C — Hybrid (default cloud, opt-out for on-prem)
+
+Default: Option A. VTIs that cannot or will not use cloud (e.g. no internet,
+strict data residency) deploy Option B with a signed support contract that
+specifies their patching SLA.
+
+## Decision Matrix (1 = poor … 5 = excellent)
+
+| Driver                        | A — Cloud SaaS | B — VTI-hosted | C — Hybrid |
+| ----------------------------- | :------------: | :------------: | :--------: |
+| D1 Data sovereignty           |       3        |       5        |     4      |
+| D2 VTI operational burden     |       5        |       1        |     4      |
+| D3 Total cost of ownership    |       5        |       2        |     4      |
+| D4 Patch/upgrade cadence      |       5        |       2        |     4      |
+| D5 Offline tolerance          |       2        |       5        |     4      |
+| D6 Security posture           |       5        |       2        |     4      |
+| D7 National reporting         |       5        |       2        |     4      |
+| D8 Vendor lock-in / exit      |       3        |       5        |     4      |
+| **Total**                     |    **33**      |     **24**     |   **32**   |
+
+## Decision
+
+**Adopt Option C — Hybrid.**
+
+- The **default** offering is the multi-tenant cloud (Option A) hosted at
+  `amis.institute`. New VTIs are provisioned as tenants via the
+  `scripts/provision-tenant.js` script (Issue #147).
+- VTIs that **cannot** use cloud — documented justifications only:
+  no/insufficient internet, written directive from a board, or sensitive
+  pilot data — may opt into **VTI-hosted single-tenant** (Option B). They
+  receive the offline Docker bundle (`docker-compose.offline.yml`) and a
+  support contract that explicitly states the patching cadence.
+- All deployments — cloud or self-hosted — share the same codebase, the
+  same PWA offline support (Issue #149), and the same outbox/queue
+  infrastructure. There is no fork.
+
+## Consequences
+
+### Positive
+
+- Clear, defensible default for stakeholders ("we host it for you").
+- Lower TCO and faster patching for the 80 % case.
+- Centralised national reporting becomes feasible (one DB, RLS-scoped views).
+- Single hardening surface for the security team.
+
+### Negative / Trade-offs
+
+- Cloud-hosted VTIs depend on `amis.institute` availability — we owe them
+  an uptime SLA (see [ADMIN-GOVERNANCE.md](../ADMIN-GOVERNANCE.md)).
+- Self-hosted VTIs add support overhead. We mitigate by limiting to
+  documented exceptions and by shipping a tested offline bundle.
+- Data residency arguments will be raised by some VTIs; we answer by
+  hosting in a regional data centre (Africa) and signing DPAs.
+
+### Follow-up actions
+
+1. Draft and publish DPA template (Issue #150).
+2. Document the offline-bundle deployment runbook (`docker-compose.offline.yml`).
+3. Define uptime SLA tiers in [ADMIN-GOVERNANCE.md](../ADMIN-GOVERNANCE.md).
+4. Add `tenant.deployment_mode` column ('cloud' | 'self_hosted') for support
+   metrics (deferred — not blocking).

--- a/scripts/provision-tenant.js
+++ b/scripts/provision-tenant.js
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * provision-tenant.js — Pre-provision an institute tenant + initial admin user.
+ *
+ * Addresses Issue #147 (pre-provision admin accounts) from the demo report.
+ * Run on the staging/prod host to onboard a new institute BEFORE the demo,
+ * so the institute admin can sign in immediately with credentials handed
+ * over via secure channel (sealed envelope / encrypted message).
+ *
+ * Usage:
+ *   DATABASE_URL=postgres://... node scripts/provision-tenant.js \
+ *     --slug greenfield-vti \
+ *     --name "Greenfield Vocational Training Institute" \
+ *     --email admin@greenfield.ac.ug \
+ *     --first "Jane" --last "Mukasa" \
+ *     [--password <plain>]      # optional; otherwise a 16-char random pw is generated
+ *
+ * Output:
+ *   Prints the slug, login URL and a one-time password to stdout.
+ *   The password is also written to ./provisioned-<slug>.txt for filing.
+ *
+ * Notes:
+ *   - Idempotent on slug+email: re-running with the same slug+email resets
+ *     the admin password to a new value (useful for "forgot password" via
+ *     out-of-band channel).
+ *   - Requires bcryptjs (already a workspace dependency of apps/api).
+ */
+
+"use strict";
+
+const { Client } = require("pg");
+const bcrypt = require("bcryptjs");
+const crypto = require("crypto");
+const fs = require("fs");
+const path = require("path");
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith("--")) continue;
+    const key = a.slice(2);
+    const val = argv[i + 1] && !argv[i + 1].startsWith("--") ? argv[++i] : "true";
+    out[key] = val;
+  }
+  return out;
+}
+
+function generatePassword(len = 16) {
+  // Crockford-ish alphabet — no ambiguous chars
+  const alphabet = "ABCDEFGHJKMNPQRSTUVWXYZ23456789abcdefghjkmnpqrstuvwxyz";
+  const bytes = crypto.randomBytes(len);
+  let out = "";
+  for (let i = 0; i < len; i++) out += alphabet[bytes[i] % alphabet.length];
+  return out;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const slug = args.slug;
+  const name = args.name;
+  const email = args.email && args.email.toLowerCase();
+  const firstName = args.first ?? null;
+  const lastName = args.last ?? null;
+  let password = args.password;
+
+  if (!slug || !name || !email) {
+    console.error(
+      "Usage: node scripts/provision-tenant.js --slug <slug> --name <name> --email <email> [--first <first>] [--last <last>] [--password <pw>]"
+    );
+    process.exit(2);
+  }
+
+  if (!process.env.DATABASE_URL) {
+    console.error("DATABASE_URL env var is required.");
+    process.exit(2);
+  }
+
+  if (!password) password = generatePassword(16);
+
+  const passwordHash = await bcrypt.hash(password, 12);
+
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+
+  try {
+    await client.query("BEGIN");
+
+    // 1) Upsert tenant by slug
+    const tenantRes = await client.query(
+      `INSERT INTO platform.tenants (slug, name)
+         VALUES ($1, $2)
+       ON CONFLICT (slug) DO UPDATE SET name = EXCLUDED.name
+       RETURNING id, slug, name`,
+      [slug, name]
+    );
+    const tenant = tenantRes.rows[0];
+
+    // 2) Upsert admin user by (tenant_id, email); reset password on conflict
+    const userRes = await client.query(
+      `INSERT INTO platform.users
+         (tenant_id, email, password_hash, role, first_name, last_name)
+       VALUES ($1, $2, $3, 'admin', $4, $5)
+       ON CONFLICT (tenant_id, email) DO UPDATE
+         SET password_hash = EXCLUDED.password_hash,
+             role          = 'admin',
+             first_name    = COALESCE(EXCLUDED.first_name, platform.users.first_name),
+             last_name     = COALESCE(EXCLUDED.last_name,  platform.users.last_name)
+       RETURNING id, email, role, first_name, last_name`,
+      [tenant.id, email, passwordHash, firstName, lastName]
+    );
+    const user = userRes.rows[0];
+
+    await client.query("COMMIT");
+
+    // 3) Write a sealed credentials file for secure handover
+    const outFile = path.join(process.cwd(), `provisioned-${slug}.txt`);
+    const body = [
+      "AMIS — Institute Provisioning",
+      "═════════════════════════════════════════════════════════════",
+      `Institute       : ${tenant.name}`,
+      `Institution code: ${tenant.slug}`,
+      `Admin email     : ${user.email}`,
+      `Temporary pwd   : ${password}`,
+      "",
+      "Login URL: https://pre.amis.institute/login",
+      "         (use the institution code above when prompted)",
+      "",
+      "First-time tasks for the admin:",
+      "  1. Change the password under Profile → Security.",
+      "  2. Invite additional staff under Users.",
+      "  3. Review institute settings.",
+      "",
+      "Deliver this file to the admin via a secure, encrypted channel",
+      "(sealed envelope, password-protected ZIP, encrypted messenger).",
+      `Generated: ${new Date().toISOString()}`,
+    ].join("\n");
+    fs.writeFileSync(outFile, body, { encoding: "utf8", mode: 0o600 });
+
+    console.log(body);
+    console.log("");
+    console.log(`Credentials also written to ${outFile} (mode 0600).`);
+  } catch (err) {
+    await client.query("ROLLBACK").catch(() => {});
+    console.error("Provisioning failed:", err.message || err);
+    process.exitCode = 1;
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #146
Closes #147
Closes #148
Closes #149
Closes #150
Closes #151

Implements all 6 demo-feedback recommendations from PROJECT_TODO review.

## Changes

**#148 - Transactional email**
- `lib/email.ts`: graceful no-op when RESEND_API_KEY missing (was: throws)
- New `isEmailConfigured()` exported; `/health` now reports email + redis state
- `docker-compose.staging.yml`: passes RESEND_*/SMTP_* envs to api
- `.env.staging.example`: documents both Resend and SMTP transports
- `DEPLOY.md` Part 6b: SPF/DKIM/DMARC setup + delivery verification

**#149 - Offline/PWA + outbox queue on staging**
- Adds `redis:7-alpine` service to staging compose with healthcheck
- api depends_on redis healthy; gets REDIS_URL=redis://redis:6379

**#147 - Pre-provision institute admins**
- New `scripts/provision-tenant.js`: upsert tenant + admin atomically
- Generates 16-char unambiguous random password (or accept --password)
- bcrypt-hashes; writes provisioned-<slug>.txt mode 0600 for secure handover

**#151 - Deployment-model ADR**
- `docs/adr/0001-deployment-model.md`: 8-driver decision matrix
- Recommends Hybrid: cloud SaaS default, VTI-hosted opt-out

**#150 - Governance & support model**
- `docs/ADMIN-GOVERNANCE.md`: roles, provisioning, SLAs, DPA, incident response

**#146 - Login UX**
- Clearer institution-code hint
- Improved multi-tenant disambiguation error copy

## Verification
- `tsc --noEmit` passes for both apps/api and apps/web
- `docker compose -f docker-compose.staging.yml config` validates clean
- No code changes to existing email send-sites (try/catch wrappers preserved)