### PR TITLE
fix(api): pin @fastify/rate-limit to ^9.1.0 (Fastify 4 compat)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,7 +14,7 @@
     "@fastify/cors": "^9.0.1",
     "@fastify/helmet": "11",
     "@fastify/multipart": "^7.7.3",
-    "@fastify/rate-limit": "10",
+    "@fastify/rate-limit": "^9.1.0",
     "@fastify/static": "^6.12.0",
     "bcryptjs": "^3.0.3",
     "bullmq": "^5.76.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
         specifier: ^7.7.3
         version: 7.7.3
       '@fastify/rate-limit':
-        specifier: '10'
-        version: 10.3.0
+        specifier: ^9.1.0
+        version: 9.1.0
       '@fastify/static':
         specifier: ^6.12.0
         version: 6.12.0
@@ -971,8 +971,8 @@ packages:
   '@fastify/multipart@7.7.3':
     resolution: {integrity: sha512-MG4Gd9FNEXc8qx0OgqoXM10EGO/dN/0iVQ8SrpFMU3d6F6KUfcqD2ZyoQhkm9LWrbiMgdHv5a43x78lASdn5GA==}
 
-  '@fastify/rate-limit@10.3.0':
-    resolution: {integrity: sha512-eIGkG9XKQs0nyynatApA3EVrojHOuq4l6fhB4eeCk4PIOeadvOJz9/4w3vGI44Go17uaXOWEcPkaD8kuKm7g6Q==}
+  '@fastify/rate-limit@9.1.0':
+    resolution: {integrity: sha512-h5dZWCkuZXN0PxwqaFQLxeln8/LNwQwH9popywmDCFdKfgpi4b/HoMH1lluy6P+30CG9yzzpSpwTCIPNB9T1JA==}
 
   '@fastify/send@2.1.0':
     resolution: {integrity: sha512-yNYiY6sDkexoJR0D8IDy3aRP3+L4wdqCpvx5WP+VtEU58sn7USmKynBzDQex5X42Zzvw2gNzzYgP90UfWShLFA==}
@@ -1766,9 +1766,6 @@ packages:
 
   fastify-plugin@4.5.1:
     resolution: {integrity: sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ==}
-
-  fastify-plugin@5.1.0:
-    resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
 
   fastify@4.29.1:
     resolution: {integrity: sha512-m2kMNHIG92tSNWv+Z3UeTR9AWLLuo7KctC7mlFPtMEVrfjIhmQhkQnT9v15qA/BfVq3vvj134Y0jl9SBje3jXQ==}
@@ -3955,10 +3952,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fastify/rate-limit@10.3.0':
+  '@fastify/rate-limit@9.1.0':
     dependencies:
       '@lukeed/ms': 2.0.2
-      fastify-plugin: 5.1.0
+      fastify-plugin: 4.5.1
       toad-cache: 3.7.1
 
   '@fastify/send@2.1.0':
@@ -4757,8 +4754,6 @@ snapshots:
   fast-uri@3.1.0: {}
 
   fastify-plugin@4.5.1: {}
-
-  fastify-plugin@5.1.0: {}
 
   fastify@4.29.1:
     dependencies:


### PR DESCRIPTION
Hotfix: @fastify/rate-limit@10 requires Fastify 5; project runs Fastify 4. Caused staging api crash-loop with FST_ERR_PLUGIN_VERSION_MISMATCH. Tests pass because rate-limit is skipped when NODE_ENV=test.