### PR TITLE
fix(api): lower pg-pool idleTimeoutMillis to 30s to prevent stale connections

### DIFF
--- a/apps/api/src/db/pool.ts
+++ b/apps/api/src/db/pool.ts
@@ -17,9 +17,9 @@ function createPool(): pg.Pool {
   const p = new Pool({
     connectionString,
     max: parseInt(process.env.PG_POOL_MAX ?? "10", 10),
-    // Keep idle connections alive for 10 minutes; after that the pool
-    // discards them cleanly and reconnects on demand.
-    idleTimeoutMillis: 600_000,
+    // Recycle idle connections after 30 s so the pool never reuses a
+    // connection that was silently dropped by the OS / NAT / firewall.
+    idleTimeoutMillis: 30_000,
     // Allow 10 s to establish a new connection — enough for Docker networking
     connectionTimeoutMillis: 10_000,
     // TCP keepalives prevent NAT/firewall from silently dropping idle conns
@@ -64,7 +64,7 @@ function getSuperPool(): pg.Pool {
     const p = new Pool({
       connectionString,
       max: 5, // small — only used for auth
-      idleTimeoutMillis: 600_000,
+      idleTimeoutMillis: 30_000,
       connectionTimeoutMillis: 10_000,
       keepAlive: true,
       keepAliveInitialDelayMillis: 10_000,


### PR DESCRIPTION
## Problem

After ~6 hours of uptime on staging, the pg-pool entered a wedged state where both existing connections and new connection attempts threw `timeout exceeded when trying to connect`. Root cause: `idleTimeoutMillis: 600_000` (10 min) allowed OS/NAT to silently drop TCP connections before the pool recycled them. The pool then couldn't recover without a manual `docker restart`.|

## Fix

Lower `idleTimeoutMillis` from `600_000` to `30_000` (30 s) in both `createPool()` and `getSuperPool()`. This ensures connections are proactively recycled well within any OS/firewall idle-connection timeout window.

## Testing

- Staging restart confirmed `database: ok` immediately after pool fix
- Existing unit tests unaffected (pool is mocked in tests)