### PR TITLE
fix(infra): require APP_URL env var in compose files for email links

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -25,6 +25,8 @@ services:
       DATABASE_URL: postgres://${POSTGRES_USER:-amis}:${POSTGRES_PASSWORD:?required}@db:5432/${POSTGRES_DB:-amis}
       JWT_SECRET: ${JWT_SECRET:?required}
       CORS_ORIGIN: ${CORS_ORIGIN:?required}
+      # Frontend URL used to build email links (reset password, welcome)
+      APP_URL: ${APP_URL:?required}
     # Published on 3001 so native Nginx can proxy_pass to localhost:3001
     ports:
       - "127.0.0.1:3001:3000"

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -49,6 +49,8 @@ services:
       DATABASE_URL: postgres://${POSTGRES_USER:-amis}:${POSTGRES_PASSWORD:?required}@db:5432/${POSTGRES_DB:-amis_staging}
       JWT_SECRET: ${JWT_SECRET:?required}
       CORS_ORIGIN: ${CORS_ORIGIN:?required}
+      # Frontend URL used to build email links (reset password, welcome)
+      APP_URL: ${APP_URL:?required}
       # BullMQ outbox queue (Issue #149 — offline/PWA support)
       REDIS_URL: redis://redis:6379
       # Transactional email — set in .env.staging (Issue #148)


### PR DESCRIPTION
Password reset and welcome emails were sending links to http://localhost:5173 because APP_URL was not set in .env.staging.\n\nBoth uth.routes.ts (reset password) and users.routes.ts (welcome email) use process.env.APP_URL ?? 'http://localhost:5173' to build the link in the email body.\n\n### Changes\n- docker-compose.staging.yml: added APP_URL: \\n- docker-compose.prod.yml: added APP_URL: \\n\nUsing :?required means the container will refuse to start if the var is missing - fail fast rather than silently send broken links.\n\n### VPS fix (immediate, no rebuild needed)\n`ash\necho 'APP_URL=https://pre.amis.institute' >> /opt/amis/.env.staging\ndocker compose -f docker-compose.staging.yml --project-name amis-staging --env-file .env.staging restart api\n`\n\nCloses issue with broken email verification links found during validation meeting.