### PR TITLE
fix(users): make password optional in POST /users (admin invite flow)

### DIFF
--- a/apps/api/src/modules/users/users.routes.ts
+++ b/apps/api/src/modules/users/users.routes.ts
@@ -60,7 +60,9 @@ const UsersQuerySchema = z.object({
 
 const CreateUserSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(1),
+  // password is optional — when omitted the API auto-generates a random
+  // temporary password; the user sets their own via the welcome-email link
+  password: z.string().min(1).optional(),
   role: z.enum(VALID_ROLES),
   firstName: z.string().min(1).optional(),
   lastName: z.string().min(1).optional(),
@@ -240,10 +242,13 @@ export async function usersRoutes(app: FastifyInstance) {
         });
       }
 
-      const { email, password, role, firstName, lastName } = parsed.data;
+      const { email, role, firstName, lastName } = parsed.data;
+      // Use caller-supplied password or auto-generate a secure random one
+      // (admin invite flow: the user will set their own via the setup link)
+      const password = parsed.data.password ?? randomBytes(24).toString("base64url");
 
-      // Validate password strength
-      if (!isValidPassword(password)) {
+      // Only validate strength when the admin explicitly supplies a password
+      if (parsed.data.password !== undefined && !isValidPassword(password)) {
         return reply
           .status(400)
           .send({ message: "Password does not meet requirements" });


### PR DESCRIPTION
## Problem

POST `/users` was returning **400** for every new user created via the admin invite form.

The frontend form sends only `email`, `firstName`, `lastName`, `role` and expects a welcome email with a password-setup link - it never sends a `password` field. But `CreateUserSchema` had `password: z.string().min(1)` (required), causing Zod validation to fail on every request.

## Root Cause

`CreateUserSchema` required `password` but the admin invite flow is passwordless on the form side - the user sets their own password via the 48-hour setup link in the welcome email.

## Fix

- Made `password` optional in `CreateUserSchema`  
- When the caller omits `password`, the API auto-generates a cryptographically-random 32-char `base64url` placeholder (`randomBytes(24).toString('base64url')`)  
- The `isValidPassword` strength check is only applied when the admin explicitly supplies a password  

This is safe because the temporary placeholder is overwritten the moment the user clicks the setup link and sets their own password.

## Testing

- [ ] Create a new user via the admin form (email + role only) ? should return 201  
- [ ] Welcome email arrives with valid setup link  
- [ ] Clicking the link allows the user to set their own password  
- [ ] Creating with an explicit weak password still returns 400  

## Notifications 500

`GET /notifications/unread-count` returning 500 is a **separate DB issue** (likely `app.notifications` table missing on staging). Fix: run `dbmate up` on the staging VPS after deploying this PR.

Closes #[POST /users 400 bug]