### PR TITLE
fix(users): make password optional in POST /users + fix healthcheck IPv6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ db/data-migration/*/raw/
 
 # Test output files
 apps/api/vitest_out*.txt
+apps/web/tsc_out*.txt
 
 # Seed/script output logs
 db/seed_out.txt
@@ -26,6 +27,7 @@ db/data-migration/
 DEMO-PREP.md
 PROJECT_TODO.md
 QA-TRACKER.md
+QA-STAGING-CHECKLIST.md
 copilot-instructions.md
 USER_TESTING_GUIDE.md
 

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,25 @@ db/seed_out.txt
 
 # Binary/document files
 *.docx
+
+# Private/PII files — never commit
+DEMO-*.csv
+*_otter_ai_transcript*
+db/data-migration/
+.copilot-context/
+
+# Internal planning/ops docs
+DEMO-PREP.md
+PROJECT_TODO.md
+QA-TRACKER.md
+copilot-instructions.md
+USER_TESTING_GUIDE.md
+
+# Internal GitHub management scripts
+scripts/close-*.ps1
+scripts/close-*.js
+scripts/create-*-issues.*
+scripts/get-issues.js
+scripts/get-project-items.js
+scripts/list-all-issues.js
+scripts/mark-done.js

--- a/TECHNICAL-INSTALLATION-MANUAL.md
+++ b/TECHNICAL-INSTALLATION-MANUAL.md
@@ -1,0 +1,647 @@
+# AMIS — Technical Installation Manual
+
+**Audience:** VTI / Institutional Technical Teams (System Administrators, IT Officers)
+**System:** Academic Management Information System (AMIS) v3.0
+**Vendor:** 3B Solutions Ltd.
+**Document version:** 1.0 — May 2026
+
+---
+
+## 1. Purpose & Scope
+
+This manual is the authoritative installation reference for technical staff at a Vocational Training Institution (VTI) that has licensed AMIS. It covers:
+
+1. **Offline / On-Premises (LAN) deployment** — *primary mode*, recommended for the majority of VTIs because it does **not** require continuous internet, runs on a single in-house server, and keeps all student data inside the institution.
+2. **Cloud / VPS deployment** — secondary mode for institutions with reliable internet that prefer remote hosting.
+3. **Hybrid considerations** — running offline as primary with periodic sync to a cloud node (data-export workflow).
+
+> **Offline-first is the default.** Every section is structured so that an institution **without internet** at the server site can still bring the system up using only the offline bundle (USB / external drive) supplied by 3B Solutions Ltd.
+
+---
+
+## 2. System Architecture
+
+AMIS is a multi-tenant SaaS-style platform packaged as **four Docker containers** that run together on a single host. The same image set runs in offline (LAN) mode and cloud mode — only configuration changes.
+
+```
+                      ┌────────────────────────────────────────────┐
+                      │   Institutional LAN (or VPS in cloud mode) │
+                      │                                            │
+   Browser  ────►  ┌──┴──┐ HTTP/HTTPS                              │
+  (Staff /         │ Web │ (React SPA, served by Nginx in image)   │
+   Students        │ :80 │                                         │
+   on LAN)         └──┬──┘                                         │
+                      │ /api/* reverse-proxied / direct to API     │
+                      ▼                                            │
+                   ┌─────┐  REST / JSON                            │
+                   │ API │  Fastify + TypeScript                   │
+                   │:3001│  JWT auth, Zod validation               │
+                   └──┬──┘                                         │
+                      │ libpq (TCP)                                │
+                      ▼                                            │
+                   ┌─────┐                                         │
+                   │ DB  │  PostgreSQL 16 (RLS-enforced isolation) │
+                   │:5432│  Persistent volume: pgdata_offline      │
+                   └─────┘                                         │
+                                                                   │
+                   ┌────────┐                                      │
+                   │migrate │  dbmate (one-shot job)               │
+                   └────────┘  Runs all 39+ SQL migrations          │
+                      └────────────────────────────────────────────┘
+```
+
+### 2.1 Components
+
+| Component | Image | Role |
+|-----------|-------|------|
+| `db` | `postgres:16-alpine` | PostgreSQL with Row-Level Security; the system of record. |
+| `api` | `amis-api:offline` | Fastify REST API, JWT auth, file uploads, reporting. |
+| `web` | `amis-web:offline` | React SPA built with Vite, served by Nginx. |
+| `migrate` | `amis-dbmate:offline` | One-shot container that applies SQL migrations on startup, then exits. |
+
+### 2.2 Multi-Tenancy & Data Isolation
+
+* AMIS is **multi-tenant**: a single AMIS install can host more than one institution (e.g. KTI + UTC Kyema) if needed.
+* Tenant isolation is enforced at the **database layer** via PostgreSQL Row-Level Security (RLS).
+* Every API request first sets the tenant context with `withTenant(tenantId, callback)` before running any query — cross-tenant access is structurally impossible from the application code.
+* For most VTIs the install will host **one tenant only** (the institution itself).
+
+### 2.3 Default Network Layout
+
+| Environment | Web port | API port | DB port |
+|-------------|---------|---------|---------|
+| Offline / LAN | `:80` (HTTP, exposed on LAN) | `:3001` (exposed on LAN) | not exposed (internal Docker network only) |
+| Cloud / VPS | `127.0.0.1:8095` (proxied by Nginx with TLS) | `127.0.0.1:3001` (proxied by Nginx) | not exposed |
+
+---
+
+## 3. Hardware & Software Requirements
+
+### 3.1 Server hardware (minimum)
+
+| Resource | Minimum | Recommended | Notes |
+|----------|---------|-------------|-------|
+| CPU | 2 cores | 4+ cores | Any x86-64; no GPU required. |
+| RAM | 4 GB | 8 GB | Postgres + Node.js + Nginx. |
+| Disk | 40 GB SSD | 120 GB SSD | Allow growth for student records, uploads, DB backups. |
+| Network | 100 Mb LAN | 1 Gb LAN | Internet only required for first-time bundle transfer / updates. |
+| UPS | Recommended | Strongly recommended | Prevents DB corruption on power loss. |
+
+### 3.2 Server operating system
+
+Either of the following is supported:
+
+* **Ubuntu Server 22.04 LTS** (recommended)
+* **Debian 12**
+* **Windows Server 2019/2022** (Docker Desktop or Docker Engine for Windows) — supported but Linux is preferred.
+
+### 3.3 Required software on the server
+
+| Software | Version | Purpose |
+|----------|---------|---------|
+| Docker Engine | 24+ | Runs all four containers. |
+| Docker Compose plugin | v2+ | Orchestrates the stack. |
+| `bash` / PowerShell 5+ | — | For running the helper scripts. |
+| (Optional) Node.js 20 | — | Only needed if you will run the data-import scripts on the server. |
+
+> If the server is **fully offline** at the time of install, Docker Engine must be pre-installed by the technical team using their distro's offline package (e.g. `.deb` files placed on USB). Docker itself is not bundled in the AMIS offline package.
+
+### 3.4 Client devices (staff / students)
+
+* Any modern browser — Chrome, Edge, Firefox (last 2 versions), Safari 16+.
+* Connected to the same LAN as the AMIS server (offline mode) or to the internet (cloud mode).
+* No client-side install — AMIS is a web application.
+
+---
+
+## 4. Pre-Install Checklist
+
+Before you begin, confirm with 3B Solutions / the institution:
+
+- [ ] Server hardware meets §3.1 and is racked, powered, and reachable on the LAN.
+- [ ] Server's **static LAN IP** is allocated (e.g. `192.168.1.100`). This IP **must not change** after install (it is baked into the web bundle).
+- [ ] Docker Engine + Docker Compose plugin are installed on the server (`docker --version`, `docker compose version`).
+- [ ] You have received the **AMIS offline bundle** (USB / external drive) from 3B Solutions Ltd. The bundle is named `offline-bundle/` and contains:
+  - `images/postgres.tar`, `images/amis-api.tar`, `images/amis-web.tar`, `images/dbmate.tar`
+  - `docker-compose.offline.yml`
+  - `.env.offline.example`
+  - `db/migrations/` (all SQL migrations)
+  - `db/data-migration/` (institution-specific seed scripts, if applicable)
+  - `load-images.ps1` (Windows) / `load-images.sh` (Linux helper if provided)
+- [ ] You have the institution's **license key / activation details** from 3B Solutions Ltd.
+- [ ] DNS / hostname plan for the server (optional but recommended — e.g. `amis.kti.local`).
+- [ ] A **backup policy** is agreed (where DB dumps will be stored — see §10).
+
+---
+
+## 5. Offline / On-Premises Installation (PRIMARY MODE)
+
+This section installs AMIS on a single LAN server using the offline bundle. It assumes **no internet access on the server** — all images and code are loaded from the bundle.
+
+### 5.1 Step 1 — Prepare the server
+
+```bash
+# Linux (Ubuntu/Debian)
+sudo mkdir -p /opt/amis
+sudo chown $USER:$USER /opt/amis
+cd /opt/amis
+```
+
+```powershell
+# Windows Server
+New-Item -ItemType Directory -Force -Path C:\amis
+Set-Location C:\amis
+```
+
+Copy the entire `offline-bundle/` folder from the USB drive into `/opt/amis` (Linux) or `C:\amis` (Windows).
+
+After the copy you should see:
+
+```
+/opt/amis/
+├── images/
+│   ├── postgres.tar
+│   ├── amis-api.tar
+│   ├── amis-web.tar
+│   └── dbmate.tar
+├── db/
+│   ├── migrations/
+│   └── data-migration/
+├── docker-compose.offline.yml
+├── .env.offline.example
+└── load-images.ps1
+```
+
+### 5.2 Step 2 — Verify Docker is running
+
+```bash
+docker --version
+docker compose version
+docker info | head -n 5
+```
+
+If Docker is **not** installed, install it first using the offline `.deb` packages provided by your distro vendor. AMIS does not ship Docker itself.
+
+### 5.3 Step 3 — Load the AMIS Docker images
+
+Linux:
+```bash
+cd /opt/amis
+docker load < images/postgres.tar
+docker load < images/amis-api.tar
+docker load < images/amis-web.tar
+docker load < images/dbmate.tar
+```
+
+Windows (PowerShell):
+```powershell
+cd C:\amis
+.\load-images.ps1
+```
+
+Confirm:
+```bash
+docker images | grep -E 'amis|postgres'
+# Expected:
+# amis-api      offline   ...
+# amis-web      offline   ...
+# amis-postgres offline   ...
+# amis-dbmate   offline   ...
+```
+
+### 5.4 Step 4 — Create the environment file
+
+```bash
+cp .env.offline.example .env.offline
+nano .env.offline      # or: notepad .env.offline (Windows)
+```
+
+Fill in **every** value. Do not leave any placeholder.
+
+| Variable | What to set | How |
+|----------|-------------|-----|
+| `POSTGRES_PASSWORD` | A strong random password for the DB superuser. | `openssl rand -base64 32` (Linux). Avoid `$` characters. |
+| `JWT_SECRET` | 64 random hex bytes. **Never share or commit.** | `openssl rand -hex 64` |
+| `CORS_ORIGIN` | `http://<server-LAN-IP>` — no trailing slash. | e.g. `http://192.168.1.100` |
+| `VITE_API_URL` | `http://<server-LAN-IP>:3001` | e.g. `http://192.168.1.100:3001` |
+| `POSTGRES_USER` | Leave as `amis` unless you have a reason to change. | — |
+| `POSTGRES_DB` | Leave as `amis`. | — |
+
+> **IP-changes warning:** `VITE_API_URL` is **baked into the web image at build time**. If the server's LAN IP changes after install, request a re-built bundle from 3B Solutions Ltd. with the new IP, or set up a DNS name on the LAN router and use that.
+
+Store `.env.offline` securely — it contains secrets.
+
+### 5.5 Step 5 — Bring up the database and apply migrations
+
+```bash
+cd /opt/amis
+
+# Start only the database first
+docker compose -f docker-compose.offline.yml --env-file .env.offline up -d db
+
+# Wait ~10 seconds for PG to be ready, then run migrations
+docker compose -f docker-compose.offline.yml --env-file .env.offline run --rm migrate
+
+# Expected: migrations applied successfully — exit code 0
+```
+
+The `migrate` container exits after applying all pending SQL files in `db/migrations/`. This is a **one-shot** job and is idempotent — running it again is safe.
+
+### 5.6 Step 6 — Start the full stack
+
+```bash
+docker compose -f docker-compose.offline.yml --env-file .env.offline up -d
+docker compose -f docker-compose.offline.yml --env-file .env.offline ps
+```
+
+Expected output:
+* `db` — running, healthy
+* `api` — running, healthy
+* `web` — running
+* `migrate` — exited (0)
+
+### 5.7 Step 7 — Seed institutional master data (first install only)
+
+If 3B Solutions has supplied institution-specific seed scripts (e.g. for UTC Kyema), run them once:
+
+```bash
+# From the server (requires Node 20 on the host) OR
+# from a workstation with an SSH tunnel to the server
+cd /opt/amis
+node db/data-migration/utc-kyema/phase1-seed.js
+# ... run remaining phases as documented in db/data-migration/<institution>/README.md
+```
+
+If your institution does **not** have pre-built seed scripts, skip this step — you will create users, departments, programmes, and courses through the AMIS web UI as the platform admin (§7).
+
+### 5.8 Step 8 — Smoke-test from the server
+
+```bash
+# API health
+curl http://localhost:3001/health
+# Expected: {"status":"ok"}
+
+# Web page returns HTTP 200
+curl -I http://localhost
+```
+
+### 5.9 Step 9 — Smoke-test from a LAN client
+
+From any laptop on the same network as the server:
+
+1. Open a browser and visit `http://<server-LAN-IP>` (e.g. `http://192.168.1.100`).
+2. The AMIS login page must load.
+3. Sign in with the platform-admin credentials supplied by 3B Solutions Ltd.
+4. Confirm that menus, dashboards, and the student list load without "Network Error".
+
+If you see a CORS error, re-check `CORS_ORIGIN` in `.env.offline` matches **exactly** the URL the browser uses.
+
+### 5.10 Step 10 — Make Docker auto-start on boot
+
+```bash
+sudo systemctl enable docker      # Linux
+
+# AMIS containers already use restart: always, so they restart with Docker.
+```
+
+On Windows Server, ensure Docker Desktop / Docker Engine service is set to **Automatic** start.
+
+---
+
+## 6. Cloud / VPS Installation (SECONDARY MODE)
+
+Use this mode only if the institution has reliable internet at the server site and prefers remote hosting. Otherwise stay with §5.
+
+### 6.1 Prerequisites
+
+* A VPS (Contabo, DigitalOcean, Hetzner, etc.) running Ubuntu 22.04 LTS.
+* SSH key access as `root` or a sudo user.
+* Two DNS A records pointing to the VPS public IP:
+  * `amis.<your-domain>` (frontend)
+  * `api.amis.<your-domain>` (API)
+* Ports `80` and `443` open on the firewall.
+
+### 6.2 Steps
+
+```bash
+ssh root@<VPS-IP>
+apt-get update
+apt-get install -y docker.io docker-compose-plugin certbot python3-certbot-nginx nginx git
+
+mkdir -p /opt/amis && cd /opt/amis
+git clone https://github.com/3bsolutionsltd/amis-multi-tenant.git .
+
+cp .env.prod.example .env
+nano .env            # fill POSTGRES_PASSWORD, JWT_SECRET, CORS_ORIGIN, VITE_API_URL
+
+docker compose -f docker-compose.prod.yml up -d --build
+
+# Install Nginx vhost + TLS
+cp nginx/amis.conf /etc/nginx/sites-available/amis.conf
+ln -s /etc/nginx/sites-available/amis.conf /etc/nginx/sites-enabled/
+nginx -t && systemctl reload nginx
+certbot --nginx -d amis.<domain> -d api.amis.<domain>
+```
+
+For full cloud deployment runbook (incl. staging, SMTP/Resend email, certbot renewal), see [DEPLOY.md](DEPLOY.md). The cloud mode reuses the same image and migration system as offline mode — the only differences are:
+
+* TLS termination at Nginx with Let's Encrypt.
+* API and Web bind to `127.0.0.1` only; Nginx is the single public entry point.
+* `.env` instead of `.env.offline`.
+
+---
+
+## 7. Post-Install: Tenant & Admin Setup
+
+After the stack is running, AMIS still needs at least one **tenant** (the institution) and one **platform admin** to be usable.
+
+### 7.1 If 3B Solutions seeded your tenant
+
+Skip this section. Use the platform-admin credentials supplied to you and continue at §7.3.
+
+### 7.2 If you must create the tenant manually
+
+The supplied installation includes a provisioning script:
+
+```bash
+node scripts/provision-tenant.js \
+    --name "Kyema Technical Institute" \
+    --slug "kti" \
+    --admin-email "admin@kti.ac.ug" \
+    --admin-password "<temporary-strong-password>"
+```
+
+The script creates:
+1. A row in `platform.tenants`.
+2. A schema-level role for the tenant.
+3. The first `admin` user.
+
+### 7.3 First login & admin checklist
+
+Log in at `http://<server-IP>/login` with the platform-admin account, then:
+
+1. Force a password change.
+2. Create departments, programmes, intakes, courses, and academic calendars.
+3. Create user accounts for: registrar, finance, HODs, instructors, principal, dean.
+4. Import students via CSV (see [USER_MANUAL.md](USER_MANUAL.md) → "Bulk Student Import").
+5. Publish a **config version** to lock the visible modules (Admissions, Enrolment, Marks, Fees, Clearance, Alumni).
+
+---
+
+## 8. Validating the Installation
+
+Run through this checklist **before** handing the system to end users.
+
+| # | Check | Expected |
+|---|-------|----------|
+| 1 | `docker compose -f docker-compose.offline.yml ps` | `db`, `api`, `web` all running and healthy. |
+| 2 | `curl http://localhost:3001/health` | `{"status":"ok"}` |
+| 3 | Login page loads on a LAN client | Login form rendered, no console errors. |
+| 4 | Login as platform admin | Dashboard renders, no CORS errors. |
+| 5 | Create a test student | Saved, appears in student list. |
+| 6 | Log out, log in as a different role | Role-specific menus only. |
+| 7 | Restart the server (`reboot`) | Containers come up automatically; AMIS reachable in <2 min. |
+| 8 | Run a manual DB backup (§10.1) | `.dump` file produced, non-zero size. |
+
+---
+
+## 9. Updating an Offline Installation
+
+VTIs without internet on the server cannot `git pull`. Updates are delivered as a **new offline bundle** from 3B Solutions Ltd. The procedure:
+
+```bash
+cd /opt/amis
+
+# 1. Take a fresh DB backup (REQUIRED — see §10.1)
+docker compose -f docker-compose.offline.yml --env-file .env.offline exec db \
+  pg_dump -U amis amis > /opt/amis/backups/pre-upgrade-$(date +%F).sql
+
+# 2. Stop running containers (data volumes are preserved)
+docker compose -f docker-compose.offline.yml --env-file .env.offline down
+
+# 3. Replace files from the new bundle
+#    - images/*.tar               (overwrite)
+#    - docker-compose.offline.yml (overwrite)
+#    - db/migrations/             (overwrite — only adds new files)
+#    - DO NOT overwrite .env.offline
+
+# 4. Load the new images
+docker load < images/amis-api.tar
+docker load < images/amis-web.tar
+# (postgres / dbmate usually unchanged — re-load only if instructed)
+
+# 5. Apply any new DB migrations
+docker compose -f docker-compose.offline.yml --env-file .env.offline up -d db
+docker compose -f docker-compose.offline.yml --env-file .env.offline run --rm migrate
+
+# 6. Bring the stack back up
+docker compose -f docker-compose.offline.yml --env-file .env.offline up -d
+```
+
+Verify the version banner in the UI footer matches the new release before announcing the update.
+
+---
+
+## 10. Backup & Restore
+
+### 10.1 Daily database backup (recommended)
+
+Create `/opt/amis/scripts/backup.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+DEST=/opt/amis/backups
+mkdir -p "$DEST"
+STAMP=$(date +%Y-%m-%d_%H%M)
+docker compose -f /opt/amis/docker-compose.offline.yml --env-file /opt/amis/.env.offline \
+  exec -T db pg_dump -U amis amis | gzip > "$DEST/amis-$STAMP.sql.gz"
+# Retain 30 days
+find "$DEST" -type f -name 'amis-*.sql.gz' -mtime +30 -delete
+```
+
+Schedule it:
+
+```bash
+chmod +x /opt/amis/scripts/backup.sh
+sudo crontab -e
+# Add:
+0 1 * * *   /opt/amis/scripts/backup.sh >> /var/log/amis-backup.log 2>&1
+```
+
+> Copy backups off the server periodically (USB, NAS, secondary VTI server).
+
+### 10.2 Restoring from backup
+
+```bash
+# Stop the API so nothing writes during restore
+docker compose -f docker-compose.offline.yml --env-file .env.offline stop api web
+
+# Drop and recreate the schema
+docker compose -f docker-compose.offline.yml --env-file .env.offline exec -T db \
+  psql -U amis -c "DROP DATABASE amis; CREATE DATABASE amis OWNER amis;"
+
+# Restore
+gunzip -c /opt/amis/backups/amis-2026-05-21_0100.sql.gz | \
+  docker compose -f docker-compose.offline.yml --env-file .env.offline exec -T db \
+  psql -U amis amis
+
+# Restart the app
+docker compose -f docker-compose.offline.yml --env-file .env.offline start api web
+```
+
+### 10.3 Backing up uploads (optional)
+
+The API writes uploads to the `uploads` Docker volume. To snapshot it:
+
+```bash
+docker run --rm -v amis_uploads:/data -v /opt/amis/backups:/backup \
+  alpine tar czf /backup/uploads-$(date +%F).tgz -C /data .
+```
+
+---
+
+## 11. Security Hardening
+
+| Area | Action |
+|------|--------|
+| Secrets | Never commit `.env.offline`. Restrict file mode: `chmod 600 .env.offline`. |
+| OS users | Run Docker as a non-root user added to the `docker` group. |
+| Firewall | Block ALL inbound ports from outside the LAN. Only `:80` (and `:443` if TLS terminated locally) and `:3001` should be reachable inside the LAN. Block from WAN entirely. |
+| TLS on LAN | Optional but recommended — issue a self-signed or internal-CA cert and front the stack with the institution's existing reverse proxy. |
+| Database | DB port `5432` is **never** exposed outside the Docker network. Verify with `ss -tlnp | grep 5432` — no listener should be on the host's LAN IP. |
+| Backups | Encrypt off-site copies (e.g. with `age` or VeraCrypt) before shipping to USB. |
+| Updates | Apply OS security patches monthly: `apt-get update && apt-get -y upgrade && reboot`. |
+| Audit | AMIS logs all auth events; review `docker logs amis-api-1 \| grep AUDIT` regularly. |
+| Roles | Use the principle of least privilege when assigning `admin`, `registrar`, `finance`, `hod`, `instructor`, `principal`, `dean` roles. |
+
+---
+
+## 12. Operational Procedures
+
+### 12.1 Daily
+
+* Verify all containers are running: `docker compose -f docker-compose.offline.yml ps`.
+* Confirm last night's backup file exists and is non-zero size.
+
+### 12.2 Weekly
+
+* Tail logs and look for repeated errors:
+  ```bash
+  docker compose -f docker-compose.offline.yml logs --since 7d api | grep -iE 'error|fatal'
+  ```
+* Free disk check: `df -h /var/lib/docker`.
+
+### 12.3 Monthly
+
+* OS security patches.
+* Test a backup restore on a separate machine (do **not** restore over production).
+* Rotate `JWT_SECRET` if the institution's policy requires it (forces all users to log in again).
+
+### 12.4 Useful day-to-day commands
+
+```bash
+# Live logs
+docker compose -f docker-compose.offline.yml logs -f api
+docker compose -f docker-compose.offline.yml logs -f web
+
+# Restart only the API
+docker compose -f docker-compose.offline.yml --env-file .env.offline restart api
+
+# Open a psql shell
+docker compose -f docker-compose.offline.yml --env-file .env.offline exec db psql -U amis amis
+
+# List applied migrations
+docker compose -f docker-compose.offline.yml --env-file .env.offline run --rm migrate status
+
+# Stop everything (data preserved)
+docker compose -f docker-compose.offline.yml --env-file .env.offline down
+
+# Stop AND DELETE all DB data (DESTRUCTIVE)
+docker compose -f docker-compose.offline.yml --env-file .env.offline down -v
+```
+
+---
+
+## 13. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Browser shows "Network Error" / CORS error after login | `CORS_ORIGIN` in `.env.offline` does not match the URL the browser is using. | Update `CORS_ORIGIN`, then `docker compose ... up -d --no-deps api`. |
+| Login spinner never completes; API logs show `ECONNREFUSED 127.0.0.1:5432` | DB container not healthy. | `docker compose ... ps` — restart `db`, check disk space. |
+| `migrate` exits with `permission denied` | Volume mount points to a path that doesn't exist. | Run from `/opt/amis`; ensure `db/migrations/` was copied from the bundle. |
+| Web image still shows old API URL after server IP change | `VITE_API_URL` is baked into the image at build time. | Request a rebuilt offline bundle from 3B Solutions Ltd. with the new IP, OR set up a stable LAN DNS name and rebuild once. |
+| Slow performance with many students | Default Postgres tuning. | Increase `shared_buffers`, `work_mem`; add a `postgresql.conf` override volume. Contact 3B Solutions for a tuned config. |
+| Cannot reach AMIS from a Wi-Fi client but wired works | LAN segregation / VLAN. | Talk to the network admin — Wi-Fi clients must reach the server's LAN IP on TCP 80 and 3001. |
+| Disk full | Postgres data growth + Docker build cache. | `docker system prune -af --volumes` (CAREFUL — preserves named volumes only). Move `pgdata` to a larger disk if needed. |
+| Forgotten platform-admin password | Direct DB reset. | Use the password-reset CLI: `docker compose ... exec api node dist/scripts/reset-password.js <email>`. |
+
+For unresolved issues, capture the following and email **support@3bsolutions.co.ug**:
+
+```bash
+docker compose -f docker-compose.offline.yml ps                  > diag.txt
+docker compose -f docker-compose.offline.yml logs --tail 500 api >> diag.txt
+docker compose -f docker-compose.offline.yml logs --tail 500 db  >> diag.txt
+uname -a >> diag.txt; docker --version >> diag.txt
+```
+
+---
+
+## 14. Hybrid / Sync Considerations (Roadmap)
+
+Some institutions will run AMIS **offline as the system of record** and periodically push a sanitized export to a cloud node for ministry reporting or alumni portals. This is supported through:
+
+1. **Daily DB dumps** (§10.1) shipped over a USB or scheduled rsync when internet is briefly available.
+2. **Tenant-scoped JSON exports** from the platform-admin UI (Settings → Export).
+3. A future **delta sync** worker (see [docs/SYNC-CONFLICT-RULES.md](docs/SYNC-CONFLICT-RULES.md)) — not required for first install.
+
+If your VTI plans to use sync, contact 3B Solutions Ltd. before installation so the cloud counterpart can be provisioned with matching tenant IDs.
+
+---
+
+## 15. Support & Escalation
+
+| Channel | Use for |
+|---------|---------|
+| **support@3bsolutions.co.ug** | All technical issues, bug reports, feature requests. |
+| Phone (during business hours) | Critical outages, install-day blockers. |
+| GitHub Issues (if private access granted) | Engineering follow-up. |
+
+When raising a ticket, include:
+
+* AMIS version (footer of UI, or `docker images | grep amis`).
+* Server OS + Docker version.
+* Last 500 lines of `api` and `db` logs.
+* Whether the system is **offline** or **cloud** mode.
+* Steps to reproduce.
+
+---
+
+## 16. Appendix A — File Reference
+
+| File | Purpose |
+|------|---------|
+| `docker-compose.offline.yml` | Compose file for LAN / on-prem deployment. |
+| `docker-compose.prod.yml` | Compose file for cloud / VPS deployment. |
+| `.env.offline.example` | Template for offline environment variables. |
+| `.env.prod.example` | Template for cloud environment variables. |
+| `db/migrations/` | All sequential SQL migrations (managed by dbmate). |
+| `db/data-migration/<institution>/` | Institution-specific seed scripts. |
+| `nginx/amis.conf` | Nginx reverse-proxy template (cloud mode). |
+| `scripts/build-offline-bundle.ps1` | (Vendor-side) creates the offline bundle. |
+| [DEPLOY.md](DEPLOY.md) | Cloud-mode deployment runbook. |
+| [USER_MANUAL.md](USER_MANUAL.md) | End-user guide. |
+| [SECURITY.md](SECURITY.md) | Vendor security policy. |
+
+## 17. Appendix B — Default Ports Summary
+
+| Port | Bound on | Purpose | Open to LAN? | Open to Internet? |
+|------|----------|---------|---------------|-------------------|
+| 80 | host (offline) / 127.0.0.1 (cloud) | Web UI | Yes (offline) | Only via Nginx + TLS (cloud) |
+| 3001 | host (offline) / 127.0.0.1 (cloud) | REST API | Yes (offline) | Only via Nginx (cloud) |
+| 5432 | docker network only | PostgreSQL | **No** | **No** |
+| 443 | host (cloud only) | Nginx HTTPS | — | Yes (cloud only) |
+
+---
+
+**End of Manual** — © 2026 3B Solutions Ltd. Distributed under the AMIS licensing terms agreed with the institution.

--- a/apps/api/src/modules/users/users.routes.ts
+++ b/apps/api/src/modules/users/users.routes.ts
@@ -60,7 +60,9 @@ const UsersQuerySchema = z.object({
 
 const CreateUserSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(1),
+  // password is optional — when omitted the API auto-generates a random
+  // temporary password; the user sets their own via the welcome-email link
+  password: z.string().min(1).optional(),
   role: z.enum(VALID_ROLES),
   firstName: z.string().min(1).optional(),
   lastName: z.string().min(1).optional(),
@@ -240,10 +242,13 @@ export async function usersRoutes(app: FastifyInstance) {
         });
       }
 
-      const { email, password, role, firstName, lastName } = parsed.data;
+      const { email, role, firstName, lastName } = parsed.data;
+      // Use caller-supplied password or auto-generate a secure random one
+      // (admin invite flow: the user will set their own via the setup link)
+      const password = parsed.data.password ?? randomBytes(24).toString("base64url");
 
-      // Validate password strength
-      if (!isValidPassword(password)) {
+      // Only validate strength when the admin explicitly supplies a password
+      if (parsed.data.password !== undefined && !isValidPassword(password)) {
         return reply
           .status(400)
           .send({ message: "Password does not meet requirements" });

--- a/docker-compose.offline.yml
+++ b/docker-compose.offline.yml
@@ -60,7 +60,7 @@ services:
       db:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/health || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3000/health || exit 1"]
       interval: 20s
       timeout: 5s
       retries: 5

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -36,7 +36,7 @@ services:
       db:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/health || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3000/health || exit 1"]
       interval: 20s
       timeout: 5s
       retries: 3

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -74,7 +74,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/health || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3000/health || exit 1"]
       interval: 20s
       timeout: 5s
       retries: 3

--- a/install-kit/MANIFEST.md
+++ b/install-kit/MANIFEST.md
@@ -1,0 +1,46 @@
+# AMIS Install Kit — Bundle Manifest
+
+> **Vendor checklist.** This file lists everything that **must be present** in `install-kit/` before the bundle is zipped and shipped to a VTI.
+
+## Required files (vendor populates)
+
+- [ ] `images/postgres.tar`         — `docker save amis-postgres:offline -o images/postgres.tar`
+- [ ] `images/amis-api.tar`         — built from `apps/api/Dockerfile`
+- [ ] `images/amis-web.tar`         — built from `apps/web/Dockerfile` with `VITE_API_URL` baked in
+- [ ] `images/dbmate.tar`           — `docker save amis-dbmate:offline -o images/dbmate.tar`
+- [ ] `db/migrations/*.sql`         — copy of latest `db/migrations/`
+- [ ] `db/data-migration/<institution>/` — institution-specific seed scripts (if applicable)
+- [ ] `docs/vendor/docsify.min.js`  — `curl -L https://cdn.jsdelivr.net/npm/docsify@4/lib/docsify.min.js -o docs/vendor/docsify.min.js`
+- [ ] `docs/vendor/vue.css`         — `curl -L https://cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css -o docs/vendor/vue.css`
+- [ ] `docs/vendor/prism-bash.min.js` — `curl -L https://cdn.jsdelivr.net/npm/prismjs@1/components/prism-bash.min.js -o docs/vendor/prism-bash.min.js`
+
+Run `scripts/prepare-offline-docs.sh` on the build machine to fetch all `vendor/` assets automatically.
+
+## Always present (already in the kit)
+
+- [x] `README.md`
+- [x] `QUICK-START.md`
+- [x] `install.sh`, `install.ps1`
+- [x] `config/docker-compose.offline.yml`
+- [x] `config/.env.offline.example`
+- [x] `scripts/*` (backup, restore, healthcheck, serve-docs, load-images, diagnostics, prepare-offline-docs)
+- [x] `docs/*.md` and `docs/index.html`
+
+## Versioning
+
+Add a `VERSION` file to the root before shipping:
+
+```
+echo "3.0.0+2026.05.21" > VERSION
+```
+
+## Build & ship
+
+```bash
+# From repo root
+./scripts/build-offline-bundle.ps1 -ServerIp 192.168.1.100
+zip -r amis-install-kit-$(cat install-kit/VERSION).zip install-kit/
+sha256sum amis-install-kit-*.zip > install-kit-checksum.txt
+```
+
+Ship the `.zip` and the `.txt` checksum on the same USB / cloud upload.

--- a/install-kit/QUICK-START.md
+++ b/install-kit/QUICK-START.md
@@ -1,0 +1,60 @@
+# AMIS — Quick Start Cheat-Sheet
+
+> Print this page and keep it next to the server.
+
+## Install (first time)
+
+```bash
+# Linux
+sudo ./install.sh
+```
+```powershell
+# Windows
+.\install.ps1
+```
+
+The installer asks you for:
+
+| Prompt | Example answer |
+|--------|----------------|
+| Server LAN IP | `192.168.1.100` |
+| Postgres password | *(auto-generated, copy it)* |
+| JWT secret | *(auto-generated)* |
+
+When it finishes, open `http://<server-IP>` in a browser on the LAN.
+
+## Default credentials
+
+The platform-admin account is supplied by 3B Solutions Ltd. on a separate sheet. Change the password on first login.
+
+## Daily operations
+
+```bash
+# Status
+docker compose -f config/docker-compose.offline.yml ps
+
+# Logs (live)
+docker compose -f config/docker-compose.offline.yml logs -f api
+
+# Restart
+docker compose -f config/docker-compose.offline.yml --env-file config/.env.offline restart api
+
+# Manual backup
+./scripts/backup.sh
+
+# Health check
+./scripts/healthcheck.sh
+```
+
+## Read the full documentation
+
+Double-click `docs/index.html` — or serve it on the LAN:
+
+```bash
+./scripts/serve-docs.sh        # http://<server-ip>:4001
+```
+
+## Get help
+
+1. `docs/13-troubleshooting.md`
+2. Email **support@3bsolutions.co.ug** with output of `./scripts/diagnostics.sh`.

--- a/install-kit/README.md
+++ b/install-kit/README.md
@@ -1,0 +1,86 @@
+# AMIS Installation Kit
+
+**Version:** 1.0 · **Audience:** VTI technical staff
+**For:** Academic Management Information System (AMIS) v3.0
+**Vendor:** 3B Solutions Ltd.
+
+This folder is a **complete, self-contained installation kit** for AMIS. Everything you need to install, run, back up, and maintain AMIS at your institution is inside.
+
+---
+
+## 🎯 Start here
+
+You have **three** ways to read the documentation. Pick one:
+
+### Option 1 — Open the docs in your browser (recommended)
+Double-click `docs/index.html`. A full web documentation site opens. It works **offline**.
+
+### Option 2 — Serve the docs on your LAN (best for teams)
+Run one script. Every staff member can then read the docs from any laptop on the LAN.
+
+```bash
+# Linux / macOS
+./scripts/serve-docs.sh           # then visit http://<server-ip>:4001
+```
+```powershell
+# Windows
+.\scripts\serve-docs.ps1          # then visit http://<server-ip>:4001
+```
+
+### Option 3 — Read the markdown files directly
+Open any file under [docs/](docs/) in a text editor or on GitHub. The numbering tells you the order.
+
+---
+
+## ⚡ Just install it (TL;DR)
+
+```bash
+# Linux
+sudo ./install.sh
+```
+```powershell
+# Windows (PowerShell as Administrator)
+.\install.ps1
+```
+
+The script will:
+
+1. Verify Docker is installed.
+2. Load all Docker images from `images/*.tar`.
+3. Create `config/.env.offline` interactively (asks you for IP, generates passwords).
+4. Apply database migrations.
+5. Start the stack.
+6. Run a health check and print the URL to open in a browser.
+
+For step-by-step manual installation, see [docs/05-install-offline.md](docs/05-install-offline.md).
+
+---
+
+## 📦 What's in this kit?
+
+| Folder / file | Purpose |
+|---------------|---------|
+| `README.md` | This file — start here. |
+| `QUICK-START.md` | 1-page printable cheat-sheet. |
+| `MANIFEST.md` | Checklist of files the vendor (3B Solutions) places in the bundle before shipping. |
+| `install.sh` / `install.ps1` | One-command installer. |
+| `config/docker-compose.offline.yml` | Container orchestration file. |
+| `config/.env.offline.example` | Environment variable template (copy → `.env.offline`). |
+| `scripts/` | Helper scripts (backup, restore, health-check, doc-server, image loaders). |
+| `docs/` | Full **web-based** documentation (Docsify). Open `docs/index.html`. |
+| `images/` | Docker images (`.tar` files) — populated by the vendor before shipping. |
+
+---
+
+## 🆘 If something goes wrong
+
+1. Read [docs/13-troubleshooting.md](docs/13-troubleshooting.md).
+2. Collect diagnostics:
+   ```bash
+   ./scripts/diagnostics.sh > diag.txt
+   ```
+3. Email **support@3bsolutions.co.ug** and attach `diag.txt`.
+
+---
+
+© 2026 3B Solutions Ltd.

--- a/install-kit/config/.env.offline.example
+++ b/install-kit/config/.env.offline.example
@@ -1,0 +1,25 @@
+# ── AMIS Offline Environment — fill in every value ───────────────────────────
+# Copy this file to .env.offline and complete all REQUIRED fields, or let
+# install.sh / install.ps1 generate them for you interactively.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ── Database ─────────────────────────────────────────────────────────────────
+POSTGRES_USER=amis
+# REQUIRED  Strong random string (min 16 chars, no '$').
+#           Generate: openssl rand -base64 24
+POSTGRES_PASSWORD=change-me-strong-password
+POSTGRES_DB=amis
+
+# ── Auth ─────────────────────────────────────────────────────────────────────
+# REQUIRED  64 random hex bytes.
+#           Linux/macOS: openssl rand -hex 64
+#           Windows    : node -e "console.log(require('crypto').randomBytes(64).toString('hex'))"
+JWT_SECRET=change-me-to-a-64-byte-random-hex-string
+
+# ── Web / CORS ───────────────────────────────────────────────────────────────
+# The URL students/staff will type into the browser.
+# Format: http://<server-LAN-IP>  — no trailing slash.
+CORS_ORIGIN=http://192.168.1.100
+
+# Baked into the Vite bundle at image build time. Must match the server's IP.
+VITE_API_URL=http://192.168.1.100:3001

--- a/install-kit/config/docker-compose.offline.yml
+++ b/install-kit/config/docker-compose.offline.yml
@@ -38,7 +38,7 @@ services:
       db:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/health || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3000/health || exit 1"]
       interval: 20s
       timeout: 5s
       retries: 5

--- a/install-kit/config/docker-compose.offline.yml
+++ b/install-kit/config/docker-compose.offline.yml
@@ -1,0 +1,71 @@
+# ── AMIS Offline / On-Premises Stack ─────────────────────────────────────────
+# Bundled copy — identical to the repo root's docker-compose.offline.yml.
+# Run from install-kit/ root:
+#   docker compose -f config/docker-compose.offline.yml --env-file config/.env.offline up -d
+# ─────────────────────────────────────────────────────────────────────────────
+
+services:
+  db:
+    image: amis-postgres:offline
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-amis}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?required}
+      POSTGRES_DB: ${POSTGRES_DB:-amis}
+    expose:
+      - "5432"
+    volumes:
+      - pgdata_offline:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-amis}"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    restart: always
+
+  api:
+    image: amis-api:offline
+    environment:
+      NODE_ENV: production
+      PORT: 3000
+      DATABASE_URL: postgres://${POSTGRES_USER:-amis}:${POSTGRES_PASSWORD:?required}@db:5432/${POSTGRES_DB:-amis}
+      JWT_SECRET: ${JWT_SECRET:?required}
+      CORS_ORIGIN: ${CORS_ORIGIN:?required}
+    ports:
+      - "0.0.0.0:3001:3000"
+    volumes:
+      - uploads:/app/apps/api/uploads
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/health || exit 1"]
+      interval: 20s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: always
+
+  web:
+    image: amis-web:offline
+    ports:
+      - "0.0.0.0:80:80"
+    depends_on:
+      api:
+        condition: service_healthy
+    restart: always
+
+  migrate:
+    image: amis-dbmate:offline
+    command: up
+    environment:
+      DATABASE_URL: postgres://${POSTGRES_USER:-amis}:${POSTGRES_PASSWORD:?required}@db:5432/${POSTGRES_DB:-amis}?sslmode=disable
+    volumes:
+      - ../db/migrations:/db/migrations:ro
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: "no"
+
+volumes:
+  pgdata_offline:
+  uploads:

--- a/install-kit/docs/01-overview.md
+++ b/install-kit/docs/01-overview.md
@@ -1,0 +1,29 @@
+# 1. Overview
+
+**AMIS** (Academic Management Information System) is a multi-tenant web application that manages the full student lifecycle at a Vocational Training Institution:
+
+- Admissions
+- Enrolment & registration
+- Marks / assessments
+- Fees & finance
+- Clearance
+- Alumni
+
+## Why offline-first?
+
+Most VTIs in the field operate with intermittent or no internet. AMIS therefore runs **entirely on a LAN server** by default. The same software also runs in the cloud if a VTI has reliable connectivity and prefers it.
+
+| Mode | Where it runs | Who uses it |
+|------|----------------|-------------|
+| **Offline / on-prem** (primary) | A single in-house server on the institution LAN | All staff, on any laptop in the institution |
+| **Cloud / VPS** (secondary) | Contabo, Hetzner, DigitalOcean, etc. | Staff and students over the public internet |
+| **Hybrid** (roadmap) | Offline as source-of-truth, cloud as read-only mirror | Ministry reporting, alumni portal |
+
+## What you get
+
+- Four Docker containers (DB, API, Web, Migrator)
+- A web UI accessible from any modern browser
+- A single ZIP install kit you can carry on a USB stick
+- One-command installer for both Linux and Windows
+
+Continue to **[02 — Architecture](02-architecture.md)**.

--- a/install-kit/docs/02-architecture.md
+++ b/install-kit/docs/02-architecture.md
@@ -1,0 +1,55 @@
+# 2. System Architecture
+
+AMIS ships as **four Docker containers** that run together on a single host.
+
+```
+                      ┌────────────────────────────────────────────┐
+                      │   Institutional LAN  (or VPS in cloud mode)│
+                      │                                            │
+   Browser  ────►  ┌──┴──┐                                         │
+  (LAN clients)    │ Web │ React SPA, served by Nginx              │
+                   │ :80 │                                         │
+                   └──┬──┘                                         │
+                      │ REST/JSON                                  │
+                      ▼                                            │
+                   ┌─────┐                                         │
+                   │ API │ Fastify + TS, JWT auth, Zod validation  │
+                   │:3001│                                         │
+                   └──┬──┘                                         │
+                      │ libpq (internal docker network)            │
+                      ▼                                            │
+                   ┌─────┐                                         │
+                   │ DB  │ PostgreSQL 16 + RLS                     │
+                   │:5432│ volume: pgdata_offline                  │
+                   └─────┘                                         │
+                                                                   │
+                   ┌────────┐                                      │
+                   │migrate │ dbmate — one-shot, idempotent        │
+                   └────────┘                                      │
+                      └────────────────────────────────────────────┘
+```
+
+## Components
+
+| Container | Image | Role |
+|-----------|-------|------|
+| `db` | `amis-postgres:offline` (=`postgres:16-alpine`) | System of record. Row-Level Security per tenant. |
+| `api` | `amis-api:offline` | Fastify REST API, JWT auth, file uploads, reporting. |
+| `web` | `amis-web:offline` | React + Vite SPA served by Nginx. |
+| `migrate` | `amis-dbmate:offline` | Applies SQL migrations on startup, then exits. |
+
+## Multi-tenancy
+
+- Tenant isolation is enforced **at the database layer** with PostgreSQL Row-Level Security (RLS).
+- Every API request sets `withTenant(tenantId, …)` before running queries.
+- Cross-tenant data access is **structurally impossible** through application code.
+- A single AMIS install can host one VTI or many (rare for on-prem; common for cloud).
+
+## Default network
+
+| Mode | Web | API | DB |
+|------|-----|-----|----|
+| Offline / LAN | `:80` exposed on LAN | `:3001` exposed on LAN | not exposed |
+| Cloud / VPS | `127.0.0.1:8095` (Nginx + TLS) | `127.0.0.1:3001` (Nginx) | not exposed |
+
+> **Database port 5432 is never exposed** — it is only reachable on the internal Docker network.

--- a/install-kit/docs/03-requirements.md
+++ b/install-kit/docs/03-requirements.md
@@ -1,0 +1,41 @@
+# 3. Requirements
+
+## Server hardware
+
+| Resource | Minimum | Recommended | Notes |
+|----------|---------|-------------|-------|
+| CPU | 2 cores | 4+ cores | x86-64; no GPU. |
+| RAM | 4 GB | 8 GB | Postgres + Node.js + Nginx. |
+| Disk | 40 GB SSD | 120 GB SSD | Allow growth for records, uploads, backups. |
+| Network | 100 Mb LAN | 1 Gb LAN | Internet not required after install. |
+| UPS | Recommended | Strongly recommended | Prevents DB corruption on power loss. |
+
+## Server operating system
+
+Any **one** of:
+
+- Ubuntu Server 22.04 LTS (recommended)
+- Debian 12
+- Windows Server 2019 / 2022 (Docker Engine or Docker Desktop)
+
+## Required server software
+
+| Software | Version | Purpose |
+|----------|---------|---------|
+| Docker Engine | 24+ | Runs the four AMIS containers |
+| Docker Compose plugin | v2+ | Orchestration |
+| `bash` or PowerShell 5+ | — | Helper scripts |
+| Node.js 20 (optional) | — | Only for running data-import scripts on the server |
+
+> **AMIS does not ship Docker.** If your server has no internet, install Docker first using offline `.deb` / `.msi` packages from your distro / Microsoft.
+
+## Client devices
+
+- Any modern browser: Chrome, Edge, Firefox (last 2 versions), Safari 16+.
+- No client install needed — AMIS is a web app.
+- Client must be on the same LAN as the server (offline mode) or reachable over the internet (cloud mode).
+
+## Network
+
+- A **static LAN IP** on the AMIS server (e.g. `192.168.1.100`). This IP **must not change** after install — it is baked into the web bundle.
+- Optional: a LAN DNS name (e.g. `amis.kti.local`) on the institution's router. Recommended if the server may ever move IP.

--- a/install-kit/docs/04-pre-install.md
+++ b/install-kit/docs/04-pre-install.md
@@ -1,0 +1,20 @@
+# 4. Pre-Install Checklist
+
+Tick every item before running the installer.
+
+- [ ] Server hardware meets [requirements](03-requirements.md) and is racked, powered, on the LAN.
+- [ ] Static LAN IP allocated and recorded — e.g. `192.168.1.100`.
+- [ ] Docker installed: `docker --version` and `docker compose version` both work.
+- [ ] You have the full **install-kit** folder (USB drive or download). It contains:
+  - `install.sh` / `install.ps1`
+  - `config/docker-compose.offline.yml`
+  - `config/.env.offline.example`
+  - `scripts/` (backup, restore, healthcheck, serve-docs, …)
+  - `docs/` (this site)
+  - `images/postgres.tar`, `amis-api.tar`, `amis-web.tar`, `dbmate.tar`
+- [ ] Verified checksum of the install kit ZIP against the `sha256` file from 3B Solutions.
+- [ ] Platform-admin credentials received from 3B Solutions (on a separate, secure channel).
+- [ ] Backup destination agreed (local disk path, external drive, NAS).
+- [ ] UPS connected.
+
+If anything is missing, **do not proceed** — contact 3B Solutions Ltd.

--- a/install-kit/docs/05-install-offline.md
+++ b/install-kit/docs/05-install-offline.md
@@ -1,0 +1,128 @@
+# 5. Offline / On-Premises Installation
+
+This is the **primary** install mode. It assumes no internet on the server itself.
+
+## Fast path — one command
+
+```bash
+# Linux
+cd /opt/amis/install-kit
+sudo ./install.sh
+```
+```powershell
+# Windows
+Set-Location C:\amis\install-kit
+.\install.ps1
+```
+
+The installer will:
+
+1. Verify Docker is reachable.
+2. `docker load` the four `images/*.tar` files.
+3. Ask you for the **server LAN IP**.
+4. Auto-generate `POSTGRES_PASSWORD` and `JWT_SECRET`.
+5. Write `config/.env.offline` (mode 600).
+6. Bring up the DB, apply all migrations, start the API and Web.
+7. Run a health check and print the URL.
+
+Skip to **[07 — First login](07-first-login.md)** when it finishes.
+
+---
+
+## Manual path (step-by-step)
+
+Use this if the automatic installer fails, or if you prefer to do it by hand.
+
+### Step 1 — Copy the kit to the server
+
+```bash
+# Linux
+sudo mkdir -p /opt/amis && sudo chown $USER:$USER /opt/amis
+cp -r /media/usb/install-kit /opt/amis/
+cd /opt/amis/install-kit
+```
+```powershell
+# Windows
+New-Item -ItemType Directory -Force -Path C:\amis | Out-Null
+Copy-Item -Recurse E:\install-kit C:\amis\
+Set-Location C:\amis\install-kit
+```
+
+### Step 2 — Load Docker images
+
+```bash
+./scripts/load-images.sh        # Linux
+```
+```powershell
+.\scripts\load-images.ps1       # Windows
+```
+
+Verify:
+
+```bash
+docker images | grep -E 'amis|postgres'
+```
+
+### Step 3 — Create the env file
+
+```bash
+cp config/.env.offline.example config/.env.offline
+nano config/.env.offline
+chmod 600 config/.env.offline
+```
+
+Fill in **every** value:
+
+| Variable | What to set | Generate with |
+|----------|-------------|----------------|
+| `POSTGRES_PASSWORD` | Strong random string (no `$`) | `openssl rand -base64 24` |
+| `JWT_SECRET` | 64 random hex bytes | `openssl rand -hex 64` |
+| `CORS_ORIGIN` | `http://<server-LAN-IP>` (no trailing `/`) | — |
+| `VITE_API_URL` | `http://<server-LAN-IP>:3001` | — |
+
+> ⚠️ `VITE_API_URL` is **baked into the web image**. If the server IP changes later, request a rebuilt image bundle from 3B Solutions or use a LAN DNS name.
+
+### Step 4 — Database + migrations
+
+```bash
+docker compose -f config/docker-compose.offline.yml --env-file config/.env.offline up -d db
+sleep 8
+docker compose -f config/docker-compose.offline.yml --env-file config/.env.offline run --rm migrate
+```
+
+### Step 5 — Start the rest of the stack
+
+```bash
+docker compose -f config/docker-compose.offline.yml --env-file config/.env.offline up -d
+docker compose -f config/docker-compose.offline.yml --env-file config/.env.offline ps
+```
+
+Expected:
+
+```
+NAME              STATUS
+amis-db-1         Up (healthy)
+amis-api-1        Up (healthy)
+amis-web-1        Up
+amis-migrate-1    Exited (0)
+```
+
+### Step 6 — Smoke test
+
+```bash
+curl http://localhost:3001/health        # {"status":"ok"}
+curl -I http://localhost                 # HTTP/1.1 200
+```
+
+From a laptop on the LAN, browse to `http://<server-LAN-IP>`. The AMIS login page must load.
+
+### Step 7 — Auto-start on boot
+
+```bash
+sudo systemctl enable docker             # Linux
+```
+Windows: ensure the Docker service is set to **Automatic** start.
+
+The AMIS containers use `restart: always` so they come back automatically with Docker.
+
+Continue to **[06 — Cloud install](06-install-cloud.md)** *(optional)* or jump to **[07 — First login](07-first-login.md)**.

--- a/install-kit/docs/05-install-offline.md
+++ b/install-kit/docs/05-install-offline.md
@@ -1,5 +1,7 @@
 # 5. Offline / On-Premises Installation
 
+> **Before you begin** — confirm that all hardware, OS, and software requirements in [§3 — Requirements](03-requirements.md) have been met, and that the [§4 — Pre-install checklist](04-pre-install.md) is fully ticked off. Skipping either will likely result in a failed install.
+
 This is the **primary** install mode. It assumes no internet on the server itself.
 
 ## Fast path — one command

--- a/install-kit/docs/06-install-cloud.md
+++ b/install-kit/docs/06-install-cloud.md
@@ -1,0 +1,44 @@
+# 6. Cloud / VPS Installation
+
+Use this mode **only** if the institution has reliable internet at the server site and prefers remote hosting. Otherwise stay with [05 — Offline install](05-install-offline.md).
+
+## Prerequisites
+
+- VPS running Ubuntu 22.04 LTS with SSH key access.
+- DNS A records pointing to the VPS:
+  - `amis.<your-domain>` (frontend)
+  - `api.amis.<your-domain>` (API)
+- Firewall: ports `80` and `443` open inbound.
+
+## Install
+
+```bash
+ssh root@<VPS-IP>
+
+apt-get update
+apt-get install -y docker.io docker-compose-plugin certbot python3-certbot-nginx nginx git
+
+mkdir -p /opt/amis && cd /opt/amis
+git clone https://github.com/3bsolutionsltd/amis-multi-tenant.git .
+
+cp .env.prod.example .env
+nano .env       # fill POSTGRES_PASSWORD, JWT_SECRET, CORS_ORIGIN, VITE_API_URL
+
+docker compose -f docker-compose.prod.yml up -d --build
+```
+
+## Nginx + TLS
+
+```bash
+cp nginx/amis.conf /etc/nginx/sites-available/amis.conf
+ln -s /etc/nginx/sites-available/amis.conf /etc/nginx/sites-enabled/
+nginx -t && systemctl reload nginx
+certbot --nginx -d amis.<domain> -d api.amis.<domain>
+```
+
+Cloud-mode bind addresses:
+- API → `127.0.0.1:3001`  (proxied by Nginx)
+- Web → `127.0.0.1:8095`  (proxied by Nginx)
+- DB  → internal docker network only
+
+For staging, transactional email (Resend), and detailed Nginx config, see the repo's `DEPLOY.md`.

--- a/install-kit/docs/07-first-login.md
+++ b/install-kit/docs/07-first-login.md
@@ -1,0 +1,39 @@
+# 7. First Login & Admin Setup
+
+After the stack is running, AMIS still needs at least one **tenant** (the institution) and a **platform admin**.
+
+## If 3B Solutions seeded your tenant
+
+Use the credentials supplied on a separate sheet and skip to [§7.3 First-login checklist](#73-first-login-checklist).
+
+## 7.1 Create the tenant manually
+
+```bash
+node scripts/provision-tenant.js \
+    --name "Kyema Technical Institute" \
+    --slug "kti" \
+    --admin-email "admin@kti.ac.ug" \
+    --admin-password "<temporary-strong-password>"
+```
+
+The script creates:
+1. A row in `platform.tenants`.
+2. A schema-level role for the tenant.
+3. The first `admin` user.
+
+## 7.2 Force a password change
+
+The platform admin must change their password on first login. The reset link is sent by email if SMTP / Resend is configured (see `DEPLOY.md`), or shown on screen.
+
+## 7.3 First-login checklist
+
+Log in at `http://<server-IP>/login`, then complete in this order:
+
+1. ✅ Change the admin password.
+2. ✅ Create departments, programmes, intakes, courses.
+3. ✅ Set up the academic calendar for the current year.
+4. ✅ Create user accounts: `registrar`, `finance`, `hod`, `instructor`, `principal`, `dean`.
+5. ✅ Import students via CSV — see the USER_MANUAL → "Bulk Student Import".
+6. ✅ Publish a **config version** to lock the visible modules (Admissions, Enrolment, Marks, Fees, Clearance, Alumni).
+
+> Until a config version is published, end users see "module not enabled" notices.

--- a/install-kit/docs/08-validate.md
+++ b/install-kit/docs/08-validate.md
@@ -1,0 +1,17 @@
+# 8. Validate the Installation
+
+Run **before** handing the system to end users.
+
+| # | Check | Expected |
+|---|-------|----------|
+| 1 | `docker compose -f config/docker-compose.offline.yml ps` | `db`, `api`, `web` running & healthy. |
+| 2 | `./scripts/healthcheck.sh` | Exit code `0`. |
+| 3 | `curl http://localhost:3001/health` | `{"status":"ok"}` |
+| 4 | Browser → `http://<server-IP>` | Login page loads, no console errors. |
+| 5 | Log in as platform admin | Dashboard renders, no CORS errors. |
+| 6 | Create a test student | Saved, appears in list. |
+| 7 | Log in as another role | Role-specific menus only. |
+| 8 | Reboot the server | Containers auto-restart, AMIS reachable in <2 min. |
+| 9 | Run `./scripts/backup.sh` | Backup file produced, non-zero size. |
+
+If any item fails, do **not** roll out yet — see [13 — Troubleshooting](13-troubleshooting.md).

--- a/install-kit/docs/09-update.md
+++ b/install-kit/docs/09-update.md
@@ -1,0 +1,45 @@
+# 9. Updating an Offline Installation
+
+Updates are delivered as a **new install-kit ZIP** from 3B Solutions Ltd. The institution does **not** need internet on the server.
+
+## Procedure
+
+```bash
+cd /opt/amis/install-kit
+
+# 1. Take a fresh backup (REQUIRED)
+./scripts/backup.sh
+
+# 2. Stop running containers (data volumes preserved)
+docker compose -f config/docker-compose.offline.yml --env-file config/.env.offline down
+
+# 3. Replace files from the new kit:
+#       images/*.tar                (overwrite)
+#       config/docker-compose.offline.yml (overwrite)
+#       db/migrations/              (overwrite — only adds new files)
+#       docs/                       (overwrite)
+#    DO NOT overwrite config/.env.offline.
+
+# 4. Load new images
+./scripts/load-images.sh
+
+# 5. Apply any new DB migrations
+docker compose -f config/docker-compose.offline.yml --env-file config/.env.offline up -d db
+docker compose -f config/docker-compose.offline.yml --env-file config/.env.offline run --rm migrate
+
+# 6. Bring the stack back up
+docker compose -f config/docker-compose.offline.yml --env-file config/.env.offline up -d
+
+# 7. Confirm the new version
+./scripts/healthcheck.sh
+```
+
+Verify the version banner in the UI footer matches the new release before announcing the update.
+
+## Rolling back
+
+```bash
+docker compose -f config/docker-compose.offline.yml --env-file config/.env.offline down
+./scripts/restore.sh backups/amis-<pre-upgrade-stamp>.sql.gz
+# Re-load the previous image tars, then up -d.
+```

--- a/install-kit/docs/10-backup.md
+++ b/install-kit/docs/10-backup.md
@@ -1,0 +1,45 @@
+# 10. Backup & Restore
+
+## 10.1 Scheduled daily backup
+
+`scripts/backup.sh` writes a gzipped `pg_dump` into `backups/` and prunes anything older than `RETENTION_DAYS` (default 30).
+
+Schedule with cron at 01:00:
+
+```bash
+sudo crontab -e
+# Add:
+0 1 * * *  /opt/amis/install-kit/scripts/backup.sh >> /var/log/amis-backup.log 2>&1
+```
+
+Windows Task Scheduler equivalent:
+
+```powershell
+schtasks /Create /SC DAILY /TN "AMIS Backup" /TR "C:\amis\install-kit\scripts\backup.sh" /ST 01:00
+```
+
+> **Always copy backups off the server** — USB, second internal disk, network share, secondary VTI server. A backup that lives only on the same disk as the database is not a backup.
+
+## 10.2 Restore from backup
+
+```bash
+./scripts/restore.sh backups/amis-2026-05-21_0100.sql.gz
+# You will be prompted to type RESTORE to confirm.
+```
+
+The script stops API/Web, drops + recreates the database, restores the dump, and starts the stack again.
+
+## 10.3 Backing up uploads
+
+The API writes uploaded files (student photos, attachments) into the `uploads` Docker volume.
+
+```bash
+docker run --rm \
+  -v amis_uploads:/data \
+  -v "$PWD/backups:/backup" \
+  alpine tar czf /backup/uploads-$(date +%F).tgz -C /data .
+```
+
+## 10.4 Disaster-recovery drill
+
+Quarterly: restore the latest backup on a **separate** machine and verify the data. Never test restore over a live production database.

--- a/install-kit/docs/11-security.md
+++ b/install-kit/docs/11-security.md
@@ -1,0 +1,33 @@
+# 11. Security Hardening
+
+| Area | Action |
+|------|--------|
+| **Secrets** | Never commit or email `.env.offline`. `chmod 600 config/.env.offline`. |
+| **OS users** | Run Docker as a non-root user added to the `docker` group. |
+| **Firewall** | Allow only ports `:80` and `:3001` inbound from the LAN. Block all WAN inbound. Use `ufw` on Ubuntu. |
+| **TLS on LAN** | Optional — issue an internal-CA cert and front the stack with your existing reverse proxy. |
+| **Database port** | `5432` must **not** appear in `ss -tlnp`. Only the internal docker network sees it. |
+| **Backups** | Encrypt off-site copies (e.g. `age`, VeraCrypt) before shipping to USB. |
+| **OS updates** | Monthly: `apt-get update && apt-get -y upgrade && reboot`. |
+| **Audit** | AMIS logs auth events. Tail with `docker compose ... logs api \| grep AUDIT`. |
+| **Roles** | Apply least privilege: `admin`, `registrar`, `finance`, `hod`, `instructor`, `principal`, `dean`. |
+| **Sessions** | JWT tokens are short-lived. Refresh tokens rotate on use. |
+| **Passwords** | Argon2id for password hashing. Minimum 10 characters enforced at the API. |
+
+## Recommended `ufw` rules (Ubuntu)
+
+```bash
+ufw default deny incoming
+ufw default allow outgoing
+ufw allow from 192.168.0.0/16 to any port 22        # SSH from LAN
+ufw allow from 192.168.0.0/16 to any port 80        # Web
+ufw allow from 192.168.0.0/16 to any port 3001      # API
+ufw enable
+ufw status verbose
+```
+
+Adjust the `192.168.0.0/16` subnet to match the institution's LAN.
+
+## Reporting a vulnerability
+
+Email **security@3bsolutions.co.ug**. See the repo's `SECURITY.md` for the disclosure policy.

--- a/install-kit/docs/12-operations.md
+++ b/install-kit/docs/12-operations.md
@@ -1,0 +1,50 @@
+# 12. Daily / Weekly / Monthly Operations
+
+## Daily
+
+- `./scripts/healthcheck.sh` — confirm all containers up.
+- Confirm last night's backup exists and is non-zero size:
+  ```bash
+  ls -lh backups/ | tail
+  ```
+
+## Weekly
+
+- Tail logs for errors:
+  ```bash
+  docker compose -f config/docker-compose.offline.yml logs --since 7d api | grep -iE 'error|fatal'
+  ```
+- Disk usage: `df -h /var/lib/docker`.
+
+## Monthly
+
+- OS security patches.
+- Test a backup restore on a separate machine.
+- Review user roles and remove leavers.
+- Optionally rotate `JWT_SECRET` (forces all users to log in again).
+
+## Useful commands
+
+```bash
+# Status
+docker compose -f config/docker-compose.offline.yml ps
+
+# Live logs
+docker compose -f config/docker-compose.offline.yml logs -f api
+docker compose -f config/docker-compose.offline.yml logs -f web
+
+# Restart only the API
+docker compose -f config/docker-compose.offline.yml --env-file config/.env.offline restart api
+
+# Open psql
+docker compose -f config/docker-compose.offline.yml --env-file config/.env.offline exec db psql -U amis amis
+
+# List applied migrations
+docker compose -f config/docker-compose.offline.yml --env-file config/.env.offline run --rm migrate status
+
+# Stop (data preserved)
+docker compose -f config/docker-compose.offline.yml --env-file config/.env.offline down
+
+# Stop AND delete DB data (DESTRUCTIVE)
+docker compose -f config/docker-compose.offline.yml --env-file config/.env.offline down -v
+```

--- a/install-kit/docs/13-troubleshooting.md
+++ b/install-kit/docs/13-troubleshooting.md
@@ -1,0 +1,23 @@
+# 13. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Browser shows "Network Error" or CORS error after login | `CORS_ORIGIN` in `.env.offline` does not match the URL the browser uses. | Edit `config/.env.offline`, then `docker compose ... up -d --no-deps api`. |
+| Login spinner never resolves; API logs show `ECONNREFUSED 127.0.0.1:5432` | DB container not healthy. | `docker compose ... ps` — restart `db`, check disk space. |
+| `migrate` exits with `permission denied` | Volume mount path wrong. | Run from `install-kit/` so the `../db/migrations` relative mount resolves. |
+| Web shows old API URL after server IP change | `VITE_API_URL` was baked into the image. | Request a rebuilt bundle from 3B Solutions with the new IP, OR set up a stable LAN DNS name and rebuild once. |
+| Slow performance with many students | Default Postgres tuning. | Increase `shared_buffers`, `work_mem`. Contact 3B Solutions for a tuned `postgresql.conf`. |
+| Wi-Fi clients can't reach AMIS but wired works | LAN segregation / VLAN. | Talk to the network admin. Wi-Fi clients need to reach the server's LAN IP on TCP 80 and 3001. |
+| Disk full | DB growth + Docker build cache. | `docker system prune -af`. Move the `pgdata_offline` volume to a larger disk. |
+| Forgotten platform-admin password | Reset CLI. | `docker compose ... exec api node dist/scripts/reset-password.js <email>` |
+| `install.sh` exits "Missing images/postgres.tar" | The bundle wasn't fully transferred. | Re-copy the kit from the USB and verify SHA-256 against the supplied checksum. |
+| Containers running but UI shows "504 Gateway Timeout" (cloud) | Nginx can't reach the API on `127.0.0.1:3001`. | `curl http://127.0.0.1:3001/health` on the VPS; check Nginx vhost. |
+
+## Capture diagnostics for a support ticket
+
+```bash
+./scripts/diagnostics.sh
+# Writes diag-YYYYmmdd-HHMM.txt — attach to your email to support.
+```
+
+The diagnostics script automatically **redacts** `POSTGRES_PASSWORD` and `JWT_SECRET` from the captured env.

--- a/install-kit/docs/14-support.md
+++ b/install-kit/docs/14-support.md
@@ -1,0 +1,28 @@
+# 14. Support & Escalation
+
+| Channel | Use for |
+|---------|---------|
+| **support@3bsolutions.co.ug** | All technical issues, bug reports, feature requests. |
+| **security@3bsolutions.co.ug** | Suspected security vulnerabilities (private). |
+| Phone (business hours) | Critical outages, install-day blockers. |
+| GitHub Issues (if private access granted) | Engineering follow-up. |
+
+## What to include in a ticket
+
+1. Output of `./scripts/diagnostics.sh` (`diag-*.txt`).
+2. AMIS version (UI footer, or `docker images | grep amis`).
+3. Whether you are running **offline** or **cloud** mode.
+4. Steps to reproduce.
+5. What you expected vs. what happened.
+6. Any recent changes (updates, network changes, hardware swaps).
+
+## SLA
+
+The SLA agreed in your institution's contract overrides anything written here. Typical response targets:
+
+| Severity | Response | Resolution target |
+|----------|----------|-------------------|
+| P1 — System down, all users blocked | 1 business hour | 1 business day |
+| P2 — Major feature broken | 4 business hours | 3 business days |
+| P3 — Minor issue / cosmetic | 1 business day | Next release |
+| P4 — Question / enhancement | 2 business days | Tracked on backlog |

--- a/install-kit/docs/99-appendix.md
+++ b/install-kit/docs/99-appendix.md
@@ -1,0 +1,57 @@
+# Appendix — Files & Ports Reference
+
+## File reference
+
+| Path (inside `install-kit/`) | Purpose |
+|------------------------------|---------|
+| `README.md` | Top-level "start here". |
+| `QUICK-START.md` | Printable cheat-sheet. |
+| `MANIFEST.md` | Vendor checklist before shipping the kit. |
+| `install.sh` / `install.ps1` | One-command installer. |
+| `config/docker-compose.offline.yml` | Container orchestration. |
+| `config/.env.offline.example` | Env template. Copy to `.env.offline`. |
+| `config/.env.offline` | Real env file (created by installer). **Mode 600. Never commit.** |
+| `scripts/load-images.sh` / `.ps1` | Loads `images/*.tar` into Docker. |
+| `scripts/backup.sh` | Nightly gzipped pg_dump. |
+| `scripts/restore.sh` | Restores from a gzipped pg_dump. |
+| `scripts/healthcheck.sh` | Quick status check. Exit 0 = OK. |
+| `scripts/diagnostics.sh` | Captures redacted logs/env for support tickets. |
+| `scripts/serve-docs.sh` / `.ps1` | Serves these docs on the LAN. |
+| `scripts/prepare-offline-docs.sh` | (Vendor) downloads docsify assets for fully-offline docs. |
+| `docs/index.html` | Web documentation entry point. |
+| `docs/*.md` | Documentation source. |
+| `docs/vendor/` | Offline copies of docsify / prism / themes (vendor-populated). |
+| `images/*.tar` | Saved Docker images (vendor-populated). |
+| `backups/` | Backup output directory (created on first run). |
+
+## Default ports
+
+| Port | Where it binds | Purpose | Open to LAN? | Open to Internet? |
+|------|----------------|---------|---------------|--------------------|
+| 80 | host (offline) / 127.0.0.1 (cloud) | Web UI | Yes (offline) | Only via Nginx + TLS (cloud) |
+| 3001 | host (offline) / 127.0.0.1 (cloud) | REST API | Yes (offline) | Only via Nginx (cloud) |
+| 4001 | host (when docs server running) | Documentation site | Yes | No |
+| 5432 | docker internal network | PostgreSQL | **No** | **No** |
+| 443 | host (cloud only) | Nginx HTTPS | — | Yes (cloud only) |
+
+## Image tags
+
+| Tag | Source | Notes |
+|-----|--------|-------|
+| `amis-postgres:offline` | `postgres:16-alpine` retagged | Same upstream image. |
+| `amis-api:offline` | Built from `apps/api/Dockerfile` | Fastify API. |
+| `amis-web:offline` | Built from `apps/web/Dockerfile` | `VITE_API_URL` baked in at build. |
+| `amis-dbmate:offline` | `ghcr.io/amacneil/dbmate:latest` retagged | Migration runner. |
+
+## Useful one-liners
+
+```bash
+# Pretty list of all AMIS containers across compose files
+docker ps --filter "name=amis"
+
+# Show env actually applied to a running container (secrets visible — careful)
+docker inspect amis-api-1 | grep -A2 Env
+
+# Tail the last 100 lines of all services
+docker compose -f config/docker-compose.offline.yml logs --tail 100
+```

--- a/install-kit/docs/README.md
+++ b/install-kit/docs/README.md
@@ -4,7 +4,7 @@ This is the **single source of truth** for installing and running AMIS at your i
 
 Use the sidebar (or the search bar) to navigate.
 
-If you only have 5 minutes, read **[Quick Start](../QUICK-START.md)** and then **[Offline install](05-install-offline.md)**.
+If you only have 5 minutes, read **[Offline install](05-install-offline.md)** (§5 covers everything from image load to first login in under 30 minutes).
 
 ## At a glance
 

--- a/install-kit/docs/README.md
+++ b/install-kit/docs/README.md
@@ -1,0 +1,28 @@
+# Welcome
+
+This is the **single source of truth** for installing and running AMIS at your institution.
+
+Use the sidebar (or the search bar) to navigate.
+
+If you only have 5 minutes, read **[Quick Start](../QUICK-START.md)** and then **[Offline install](05-install-offline.md)**.
+
+## At a glance
+
+| Task | Where to look |
+|------|----------------|
+| First-time install | [05 — Offline install](05-install-offline.md) |
+| Daily ops | [12 — Operations](12-operations.md) |
+| Something broken | [13 — Troubleshooting](13-troubleshooting.md) |
+| Apply an update | [09 — Updating](09-update.md) |
+| Disaster recovery | [10 — Backup & restore](10-backup.md) |
+
+## Serve these docs on your LAN
+
+Run **once** on the AMIS server so everyone in the institution reads the same documentation:
+
+```bash
+./scripts/serve-docs.sh           # Linux
+.\scripts\serve-docs.ps1          # Windows
+```
+
+Then bookmark `http://<server-ip>:4001` on every staff workstation.

--- a/install-kit/docs/_coverpage.md
+++ b/install-kit/docs/_coverpage.md
@@ -9,4 +9,4 @@
 - 🛠️ One-command installer for Linux & Windows
 
 [GitHub](https://github.com/3bsolutionsltd/amis-multi-tenant)
-[Get Started](#/01-overview)
+[Get Started](01-overview.md)

--- a/install-kit/docs/_coverpage.md
+++ b/install-kit/docs/_coverpage.md
@@ -1,0 +1,12 @@
+# AMIS — Installation & Operations Manual <small>v3.0</small>
+
+> One system, one source of truth.
+> Offline-first by design. Cloud-ready when you want it.
+
+- 📦 Single ZIP install kit — USB-ready
+- 🌐 Multi-tenant, RLS-isolated PostgreSQL
+- 🔐 JWT auth + role-based access
+- 🛠️ One-command installer for Linux & Windows
+
+[GitHub](https://github.com/3bsolutionsltd/amis-multi-tenant)
+[Get Started](#/01-overview)

--- a/install-kit/docs/_sidebar.md
+++ b/install-kit/docs/_sidebar.md
@@ -1,0 +1,22 @@
+* **Introduction**
+  * [Overview](01-overview.md)
+  * [System architecture](02-architecture.md)
+  * [Requirements](03-requirements.md)
+
+* **Installation**
+  * [Pre-install checklist](04-pre-install.md)
+  * [Offline / on-premises (primary)](05-install-offline.md)
+  * [Cloud / VPS (secondary)](06-install-cloud.md)
+  * [First login & admin setup](07-first-login.md)
+  * [Validate the installation](08-validate.md)
+
+* **Operations**
+  * [Updating AMIS](09-update.md)
+  * [Backup & restore](10-backup.md)
+  * [Security hardening](11-security.md)
+  * [Daily / weekly / monthly](12-operations.md)
+
+* **Support**
+  * [Troubleshooting](13-troubleshooting.md)
+  * [Support & escalation](14-support.md)
+  * [Appendix: files & ports](99-appendix.md)

--- a/install-kit/docs/index.html
+++ b/install-kit/docs/index.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>AMIS — Installation & Operations Manual</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="AMIS Academic Management Information System — Installation, configuration and operations." />
+  <!--
+    Asset loading strategy:
+      - If the bundle ships with ./vendor/* (vendor ran scripts/prepare-offline-docs.sh)
+        we use those for fully-offline operation.
+      - Otherwise we fall back to the jsDelivr CDN (requires internet on the viewer).
+    A tiny <script> below decides which to use.
+  -->
+  <link rel="stylesheet" id="theme-css" />
+  <script>
+    (function () {
+      // Try vendor first
+      var probe = new XMLHttpRequest();
+      probe.open('HEAD', 'vendor/docsify.min.js', false);
+      try { probe.send(); } catch (e) {}
+      var offline = probe.status >= 200 && probe.status < 400;
+      var base = offline
+        ? { theme: 'vendor/vue.css',
+            docsify: 'vendor/docsify.min.js',
+            bash: 'vendor/prism-bash.min.js',
+            ps: 'vendor/prism-powershell.min.js',
+            sql: 'vendor/prism-sql.min.js',
+            copy: 'vendor/docsify-copy-code.min.js' }
+        : { theme: 'https://cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css',
+            docsify: 'https://cdn.jsdelivr.net/npm/docsify@4/lib/docsify.min.js',
+            bash: 'https://cdn.jsdelivr.net/npm/prismjs@1/components/prism-bash.min.js',
+            ps: 'https://cdn.jsdelivr.net/npm/prismjs@1/components/prism-powershell.min.js',
+            sql: 'https://cdn.jsdelivr.net/npm/prismjs@1/components/prism-sql.min.js',
+            copy: 'https://cdn.jsdelivr.net/npm/docsify-copy-code@2/dist/docsify-copy-code.min.js' };
+
+      document.getElementById('theme-css').href = base.theme;
+      window.__amisAssets = base;
+    })();
+  </script>
+  <style>
+    :root {
+      --theme-color: #0a6b3d;
+      --text-color-base: #2c3e50;
+    }
+    .app-name-link img { max-width: 140px; }
+    .sidebar > h1 { font-size: 1.3rem; }
+    .markdown-section pre > code { font-size: 0.85rem; }
+    .cover-main blockquote { border-left: 4px solid var(--theme-color); }
+  </style>
+</head>
+<body>
+  <div id="app">Loading the AMIS manual…</div>
+
+  <script>
+    window.$docsify = {
+      name: 'AMIS Manual',
+      repo: '3bsolutionsltd/amis-multi-tenant',
+      loadSidebar: true,
+      loadNavbar: false,
+      coverpage: true,
+      onlyCover: false,
+      auto2top: true,
+      maxLevel: 3,
+      subMaxLevel: 2,
+      search: {
+        placeholder: 'Search the manual…',
+        noData: 'No results.',
+        depth: 3
+      },
+      copyCode: {
+        buttonText: 'Copy',
+        successText: 'Copied!'
+      },
+      themeColor: '#0a6b3d'
+    };
+  </script>
+
+  <!-- Loaders -->
+  <script>
+    function s(src){var t=document.createElement('script');t.src=src;t.async=false;document.head.appendChild(t);}
+    s(window.__amisAssets.docsify);
+    s(window.__amisAssets.copy);
+    s(window.__amisAssets.bash);
+    s(window.__amisAssets.ps);
+    s(window.__amisAssets.sql);
+  </script>
+</body>
+</html>

--- a/install-kit/docs/index.html
+++ b/install-kit/docs/index.html
@@ -56,6 +56,7 @@
     window.$docsify = {
       name: 'AMIS Manual',
       repo: '3bsolutionsltd/amis-multi-tenant',
+      routerMode: 'history',
       loadSidebar: true,
       loadNavbar: false,
       coverpage: true,

--- a/install-kit/docs/vendor/README.md
+++ b/install-kit/docs/vendor/README.md
@@ -1,0 +1,14 @@
+# Vendor docsify assets
+
+The `scripts/prepare-offline-docs.sh` script downloads docsify, prism, and the theme into this folder so the documentation site at `docs/index.html` works fully offline (no CDN required).
+
+After running the prep script you should see:
+
+- `docsify.min.js`
+- `vue.css`
+- `prism-bash.min.js`
+- `prism-powershell.min.js`
+- `prism-sql.min.js`
+- `docsify-copy-code.min.js`
+
+If this folder is empty, `docs/index.html` falls back to the jsDelivr CDN (requires internet to view the docs).

--- a/install-kit/images/README.md
+++ b/install-kit/images/README.md
@@ -1,0 +1,11 @@
+# Placeholder
+
+The vendor (3B Solutions Ltd.) places Docker image `.tar` files here before shipping the kit.
+
+Required:
+- `postgres.tar`
+- `amis-api.tar`
+- `amis-web.tar`
+- `dbmate.tar`
+
+Build them on a connected machine with `scripts/build-offline-bundle.ps1` at the repo root. See `MANIFEST.md`.

--- a/install-kit/install.ps1
+++ b/install-kit/install.ps1
@@ -1,0 +1,92 @@
+<#
+.SYNOPSIS  AMIS one-command installer (Windows Server / Docker Desktop)
+.EXAMPLE   .\install.ps1
+#>
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$KitDir       = $PSScriptRoot
+$ComposeFile  = Join-Path $KitDir 'config\docker-compose.offline.yml'
+$EnvFile      = Join-Path $KitDir 'config\.env.offline'
+$EnvTemplate  = Join-Path $KitDir 'config\.env.offline.example'
+
+function Cyan ($m) { Write-Host $m -ForegroundColor Cyan }
+function Green($m) { Write-Host $m -ForegroundColor Green }
+function Warn ($m) { Write-Host $m -ForegroundColor Yellow }
+function Red  ($m) { Write-Host $m -ForegroundColor Red }
+
+Cyan "============================================="
+Cyan "  AMIS Offline Installer (Windows)"
+Cyan "============================================="
+""
+
+# ── 1. Pre-flight ──────────────────────────────────────────────
+Cyan "[1/6] Checking prerequisites..."
+try { docker --version | Out-Null } catch { Red "Docker not installed."; exit 1 }
+try { docker compose version | Out-Null } catch { Red "Docker Compose plugin missing."; exit 1 }
+try { docker info | Out-Null } catch { Red "Docker daemon not reachable."; exit 1 }
+Green ("  Docker OK ({0})" -f (docker --version))
+
+# ── 2. Load images ─────────────────────────────────────────────
+Cyan "[2/6] Loading Docker images from images\..."
+$tars = 'postgres.tar','amis-api.tar','amis-web.tar','dbmate.tar'
+foreach ($t in $tars) {
+    $p = Join-Path $KitDir "images\$t"
+    if (-not (Test-Path $p)) { Red "Missing $p — bundle incomplete. See MANIFEST.md."; exit 1 }
+    Write-Host "  loading $t..."
+    docker load -i $p | Out-Null
+}
+Green "  All images loaded."
+
+# ── 3. Configure .env.offline ──────────────────────────────────
+Cyan "[3/6] Configuring environment..."
+if (Test-Path $EnvFile) {
+    Warn "  $EnvFile already exists — keeping it."
+} else {
+    $serverIp = Read-Host "  Server LAN IP (e.g. 192.168.1.100)"
+    if ([string]::IsNullOrWhiteSpace($serverIp)) { Red "IP is required"; exit 1 }
+
+    $pg  = [Convert]::ToBase64String((1..24 | ForEach-Object { Get-Random -Max 256 } | ForEach-Object { [byte]$_ })) -replace '[/+=]',''
+    $jwt = -join ((1..128) | ForEach-Object { '{0:x}' -f (Get-Random -Max 16) })
+
+    (Get-Content $EnvTemplate) `
+        -replace '^POSTGRES_PASSWORD=.*', "POSTGRES_PASSWORD=$pg" `
+        -replace '^JWT_SECRET=.*',        "JWT_SECRET=$jwt" `
+        -replace '^CORS_ORIGIN=.*',       "CORS_ORIGIN=http://$serverIp" `
+        -replace '^VITE_API_URL=.*',      "VITE_API_URL=http://${serverIp}:3001" |
+        Set-Content $EnvFile -Encoding ASCII
+
+    Green "  Generated $EnvFile. KEEP IT SAFE."
+    Warn  "  Postgres password (record this!): $pg"
+}
+
+# ── 4. DB + migrations ─────────────────────────────────────────
+Cyan "[4/6] Starting database and applying migrations..."
+docker compose -f $ComposeFile --env-file $EnvFile up -d db
+Start-Sleep -Seconds 8
+docker compose -f $ComposeFile --env-file $EnvFile run --rm migrate
+
+# ── 5. Start stack ─────────────────────────────────────────────
+Cyan "[5/6] Starting API and Web..."
+docker compose -f $ComposeFile --env-file $EnvFile up -d
+Start-Sleep -Seconds 5
+
+# ── 6. Health check ────────────────────────────────────────────
+Cyan "[6/6] Health check..."
+try {
+    $r = Invoke-WebRequest -UseBasicParsing -Uri 'http://localhost:3001/health' -TimeoutSec 5
+    if ($r.StatusCode -eq 200) { Green "  API healthy." } else { Warn "  API returned $($r.StatusCode)" }
+} catch { Warn "  API not healthy yet — check 'docker compose logs api'" }
+
+$ip = ((Get-Content $EnvFile) -match '^CORS_ORIGIN=') -replace 'CORS_ORIGIN=http://',''
+""
+Green "============================================="
+Green "  AMIS is installed!"
+Green "  Open this URL in any LAN browser:"
+Green ("      http://{0}" -f $ip)
+Green "============================================="
+""
+Write-Host "Next steps:"
+Write-Host "  - Log in with the platform-admin credentials supplied by 3B Solutions."
+Write-Host "  - Read docs\07-first-login.md."
+Write-Host "  - Schedule daily backups: see docs\10-backup.md."

--- a/install-kit/install.sh
+++ b/install-kit/install.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# AMIS one-command installer (Linux / macOS)
+# Usage:  sudo ./install.sh
+set -euo pipefail
+
+KIT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_FILE="$KIT_DIR/config/docker-compose.offline.yml"
+ENV_FILE="$KIT_DIR/config/.env.offline"
+ENV_TEMPLATE="$KIT_DIR/config/.env.offline.example"
+
+cyan()  { printf '\033[36m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+red()   { printf '\033[31m%s\033[0m\n' "$*" >&2; }
+warn()  { printf '\033[33m%s\033[0m\n' "$*"; }
+
+cyan "============================================="
+cyan "  AMIS Offline Installer"
+cyan "============================================="
+echo
+
+# ── 1. Pre-flight ────────────────────────────────────────────────
+cyan "[1/6] Checking prerequisites..."
+if ! command -v docker >/dev/null 2>&1; then
+  red "Docker is not installed. Install Docker Engine first."
+  red "See: docs/03-requirements.md"
+  exit 1
+fi
+if ! docker compose version >/dev/null 2>&1; then
+  red "Docker Compose plugin missing. Install docker-compose-plugin."
+  exit 1
+fi
+if ! docker info >/dev/null 2>&1; then
+  red "Cannot talk to the Docker daemon. Is it running? Are you in the docker group?"
+  exit 1
+fi
+green "  Docker OK ($(docker --version))"
+
+# ── 2. Load images ───────────────────────────────────────────────
+cyan "[2/6] Loading Docker images from images/..."
+for tar in postgres.tar amis-api.tar amis-web.tar dbmate.tar; do
+  if [[ ! -f "$KIT_DIR/images/$tar" ]]; then
+    red "Missing $KIT_DIR/images/$tar — bundle incomplete. See MANIFEST.md."
+    exit 1
+  fi
+  echo "  loading $tar..."
+  docker load -i "$KIT_DIR/images/$tar" >/dev/null
+done
+green "  All images loaded."
+
+# ── 3. Build / verify .env.offline ───────────────────────────────
+cyan "[3/6] Configuring environment..."
+if [[ -f "$ENV_FILE" ]]; then
+  warn "  $ENV_FILE already exists — keeping it."
+else
+  read -r -p "  Server LAN IP (e.g. 192.168.1.100): " SERVER_IP
+  if [[ -z "$SERVER_IP" ]]; then red "IP is required"; exit 1; fi
+
+  PG_PW=$(openssl rand -base64 24 | tr -d '/+=$' | head -c 32)
+  JWT=$(openssl rand -hex 64)
+
+  cp "$ENV_TEMPLATE" "$ENV_FILE"
+  sed -i.bak \
+    -e "s|^POSTGRES_PASSWORD=.*|POSTGRES_PASSWORD=${PG_PW}|" \
+    -e "s|^JWT_SECRET=.*|JWT_SECRET=${JWT}|" \
+    -e "s|^CORS_ORIGIN=.*|CORS_ORIGIN=http://${SERVER_IP}|" \
+    -e "s|^VITE_API_URL=.*|VITE_API_URL=http://${SERVER_IP}:3001|" \
+    "$ENV_FILE"
+  rm -f "${ENV_FILE}.bak"
+  chmod 600 "$ENV_FILE"
+  green "  Generated $ENV_FILE (mode 600). KEEP IT SAFE."
+  warn  "  Postgres password (record this!): ${PG_PW}"
+fi
+
+# ── 4. Database + migrations ─────────────────────────────────────
+cyan "[4/6] Starting database and applying migrations..."
+docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d db
+sleep 8
+docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" run --rm migrate
+
+# ── 5. Start the stack ───────────────────────────────────────────
+cyan "[5/6] Starting API and Web..."
+docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d
+sleep 5
+
+# ── 6. Health check ──────────────────────────────────────────────
+cyan "[6/6] Health check..."
+if curl -fsS http://localhost:3001/health >/dev/null; then
+  green "  API healthy."
+else
+  warn "  API not healthy yet — check 'docker compose logs api'"
+fi
+
+SERVER_IP_PRINT=$(grep '^CORS_ORIGIN=' "$ENV_FILE" | sed 's|CORS_ORIGIN=http://||')
+echo
+green "============================================="
+green "  AMIS is installed!"
+green "  Open this URL in any LAN browser:"
+green "      http://${SERVER_IP_PRINT}"
+green "============================================="
+echo
+echo "Next steps:"
+echo "  - Log in with the platform-admin credentials supplied by 3B Solutions."
+echo "  - Read docs/07-first-login.md."
+echo "  - Schedule daily backups:  see docs/10-backup.md."

--- a/install-kit/scripts/backup.sh
+++ b/install-kit/scripts/backup.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Nightly database backup. Run from cron at 01:00.
+set -euo pipefail
+KIT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE="$KIT_DIR/config/docker-compose.offline.yml"
+ENV_FILE="$KIT_DIR/config/.env.offline"
+DEST="${BACKUP_DIR:-$KIT_DIR/backups}"
+RETENTION_DAYS="${RETENTION_DAYS:-30}"
+
+mkdir -p "$DEST"
+STAMP=$(date +%Y-%m-%d_%H%M)
+OUT="$DEST/amis-${STAMP}.sql.gz"
+
+echo "[$(date)] Backing up to $OUT"
+docker compose -f "$COMPOSE" --env-file "$ENV_FILE" exec -T db \
+    pg_dump -U "${POSTGRES_USER:-amis}" "${POSTGRES_DB:-amis}" | gzip > "$OUT"
+
+SIZE=$(stat -c%s "$OUT" 2>/dev/null || stat -f%z "$OUT")
+echo "[$(date)] OK ($SIZE bytes)"
+
+# Retention
+find "$DEST" -type f -name 'amis-*.sql.gz' -mtime "+${RETENTION_DAYS}" -delete
+echo "[$(date)] Pruned backups older than ${RETENTION_DAYS} days."

--- a/install-kit/scripts/diagnostics.sh
+++ b/install-kit/scripts/diagnostics.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Capture diagnostics for support tickets.
+# Output:  diag-YYYYmmdd-HHMM.txt in current directory.
+set -uo pipefail
+KIT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE="$KIT_DIR/config/docker-compose.offline.yml"
+ENV_FILE="$KIT_DIR/config/.env.offline"
+
+OUT="diag-$(date +%Y%m%d-%H%M).txt"
+{
+  echo "===== AMIS Diagnostics ($(date)) ====="
+  echo
+  echo "----- uname -----";          uname -a
+  echo "----- docker -----";         docker --version
+  docker compose version
+  echo
+  echo "----- compose ps -----";     docker compose -f "$COMPOSE" --env-file "$ENV_FILE" ps
+  echo
+  echo "----- images -----";         docker images | grep -E 'amis|postgres'
+  echo
+  echo "----- API logs (tail 500) -----"
+  docker compose -f "$COMPOSE" --env-file "$ENV_FILE" logs --tail 500 api
+  echo
+  echo "----- DB logs (tail 200) -----"
+  docker compose -f "$COMPOSE" --env-file "$ENV_FILE" logs --tail 200 db
+  echo
+  echo "----- Web logs (tail 100) -----"
+  docker compose -f "$COMPOSE" --env-file "$ENV_FILE" logs --tail 100 web
+  echo
+  echo "----- Disk -----";           df -h
+  echo
+  echo "----- Env (secrets redacted) -----"
+  grep -v -E '^(POSTGRES_PASSWORD|JWT_SECRET)=' "$ENV_FILE" 2>/dev/null || echo "(no env file)"
+} > "$OUT" 2>&1
+echo "Wrote $OUT"

--- a/install-kit/scripts/healthcheck.sh
+++ b/install-kit/scripts/healthcheck.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Quick health check.  Exit 0 if all containers up and API healthy, else 1.
+set -uo pipefail
+KIT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE="$KIT_DIR/config/docker-compose.offline.yml"
+ENV_FILE="$KIT_DIR/config/.env.offline"
+
+fail=0
+
+echo "== Containers =="
+docker compose -f "$COMPOSE" --env-file "$ENV_FILE" ps || fail=1
+
+echo
+echo "== API /health =="
+if curl -fsS http://localhost:3001/health; then
+  echo " OK"
+else
+  echo " FAIL"; fail=1
+fi
+
+echo
+echo "== Web :80 =="
+code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost/)
+echo "  HTTP $code"
+[[ "$code" == "200" ]] || fail=1
+
+echo
+echo "== Disk =="
+df -h / | tail -n 1
+
+exit $fail

--- a/install-kit/scripts/load-images.ps1
+++ b/install-kit/scripts/load-images.ps1
@@ -1,0 +1,12 @@
+# Load all AMIS Docker images from images\*.tar
+$ErrorActionPreference = 'Stop'
+$KitDir = Split-Path -Parent $PSScriptRoot
+Push-Location (Join-Path $KitDir 'images')
+try {
+    foreach ($t in 'postgres.tar','amis-api.tar','amis-web.tar','dbmate.tar') {
+        if (-not (Test-Path $t)) { throw "Missing $t" }
+        Write-Host "Loading $t..."
+        docker load -i $t
+    }
+    Write-Host "Done. Next: ..\install.ps1"
+} finally { Pop-Location }

--- a/install-kit/scripts/load-images.sh
+++ b/install-kit/scripts/load-images.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Load all AMIS Docker images from images/*.tar
+set -euo pipefail
+KIT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$KIT_DIR/images"
+for tar in postgres.tar amis-api.tar amis-web.tar dbmate.tar; do
+  [[ -f "$tar" ]] || { echo "Missing $tar" >&2; exit 1; }
+  echo "Loading $tar..."
+  docker load -i "$tar"
+done
+echo "Done. Next: ../install.sh"

--- a/install-kit/scripts/prepare-offline-docs.sh
+++ b/install-kit/scripts/prepare-offline-docs.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Vendor-side: download Docsify assets into install-kit/docs/vendor/ so the
+# docs site works fully offline.  Run once on the build machine before zipping.
+set -euo pipefail
+KIT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VENDOR="$KIT_DIR/docs/vendor"
+mkdir -p "$VENDOR"
+
+dl() {
+  local url="$1" dest="$2"
+  echo "  $url"
+  curl -fsSL "$url" -o "$dest"
+}
+
+dl https://cdn.jsdelivr.net/npm/docsify@4/lib/docsify.min.js          "$VENDOR/docsify.min.js"
+dl https://cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css          "$VENDOR/vue.css"
+dl https://cdn.jsdelivr.net/npm/prismjs@1/components/prism-bash.min.js "$VENDOR/prism-bash.min.js"
+dl https://cdn.jsdelivr.net/npm/prismjs@1/components/prism-powershell.min.js "$VENDOR/prism-powershell.min.js"
+dl https://cdn.jsdelivr.net/npm/prismjs@1/components/prism-sql.min.js "$VENDOR/prism-sql.min.js"
+dl https://cdn.jsdelivr.net/npm/docsify-copy-code@2/dist/docsify-copy-code.min.js "$VENDOR/docsify-copy-code.min.js"
+
+echo "Done. docs/index.html will use ./vendor/ when assets exist."

--- a/install-kit/scripts/restore.sh
+++ b/install-kit/scripts/restore.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Restore the AMIS database from a gzipped pg_dump.
+# Usage:  ./scripts/restore.sh backups/amis-2026-05-21_0100.sql.gz
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <backup-file.sql.gz>" >&2
+  exit 1
+fi
+DUMP="$1"
+[[ -f "$DUMP" ]] || { echo "File not found: $DUMP" >&2; exit 1; }
+
+KIT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE="$KIT_DIR/config/docker-compose.offline.yml"
+ENV_FILE="$KIT_DIR/config/.env.offline"
+
+read -r -p "This will OVERWRITE the current database. Type 'RESTORE' to continue: " ans
+[[ "$ans" == "RESTORE" ]] || { echo "Aborted."; exit 1; }
+
+echo "[1/4] Stopping API/Web..."
+docker compose -f "$COMPOSE" --env-file "$ENV_FILE" stop api web
+
+echo "[2/4] Dropping & recreating database..."
+docker compose -f "$COMPOSE" --env-file "$ENV_FILE" exec -T db \
+    psql -U amis -d postgres -c "DROP DATABASE IF EXISTS amis;"
+docker compose -f "$COMPOSE" --env-file "$ENV_FILE" exec -T db \
+    psql -U amis -d postgres -c "CREATE DATABASE amis OWNER amis;"
+
+echo "[3/4] Restoring from $DUMP ..."
+gunzip -c "$DUMP" | docker compose -f "$COMPOSE" --env-file "$ENV_FILE" exec -T db psql -U amis amis
+
+echo "[4/4] Restarting services..."
+docker compose -f "$COMPOSE" --env-file "$ENV_FILE" start api web
+
+echo "Done."

--- a/install-kit/scripts/serve-docs.ps1
+++ b/install-kit/scripts/serve-docs.ps1
@@ -1,0 +1,24 @@
+# Serve the AMIS documentation on the LAN as a single source of truth.
+# Default port 4001.  .\scripts\serve-docs.ps1 -Port 8080
+param([int]$Port = 4001)
+
+$ErrorActionPreference = 'Stop'
+$KitDir  = Split-Path -Parent $PSScriptRoot
+$DocsDir = Join-Path $KitDir 'docs'
+
+Push-Location $DocsDir
+try {
+    $ip = (Get-NetIPAddress -AddressFamily IPv4 |
+           Where-Object { $_.IPAddress -notlike '127.*' -and $_.IPAddress -notlike '169.*' } |
+           Select-Object -First 1).IPAddress
+    Write-Host "Docs available at: http://$ip:$Port" -ForegroundColor Green
+    Write-Host "Press Ctrl-C to stop." -ForegroundColor Yellow
+
+    $py = Get-Command python -ErrorAction SilentlyContinue
+    if ($py) {
+        & $py -m http.server $Port --bind 0.0.0.0
+    } else {
+        Write-Host "Python not found — falling back to Docker." -ForegroundColor Yellow
+        docker run --rm -p "${Port}:80" -v "${DocsDir}:/usr/share/nginx/html:ro" nginx:alpine
+    }
+} finally { Pop-Location }

--- a/install-kit/scripts/serve-docs.sh
+++ b/install-kit/scripts/serve-docs.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Serve the AMIS documentation on the LAN as a single source of truth.
+# Default port: 4001.  Override with PORT=8080 ./scripts/serve-docs.sh
+set -euo pipefail
+KIT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DOCS_DIR="$KIT_DIR/docs"
+PORT="${PORT:-4001}"
+
+cd "$DOCS_DIR"
+
+# Try Python (very widely available), fall back to a Docker one-liner.
+if command -v python3 >/dev/null 2>&1; then
+  echo "Docs are available at: http://$(hostname -I | awk '{print $1}'):${PORT}"
+  echo "Press Ctrl-C to stop."
+  exec python3 -m http.server "$PORT" --bind 0.0.0.0
+elif command -v python >/dev/null 2>&1; then
+  exec python -m http.server "$PORT" --bind 0.0.0.0
+else
+  echo "Python not found — falling back to Docker."
+  exec docker run --rm -p "${PORT}:80" -v "$DOCS_DIR:/usr/share/nginx/html:ro" nginx:alpine
+fi

--- a/nginx/docs.amis.institute.conf
+++ b/nginx/docs.amis.institute.conf
@@ -1,0 +1,42 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name docs.amis.institute;
+
+    # Redirect all HTTP to HTTPS
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name docs.amis.institute;
+
+    # TLS — managed by certbot
+    ssl_certificate     /etc/letsencrypt/live/docs.amis.institute/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/docs.amis.institute/privkey.pem;
+    include             /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam         /etc/letsencrypt/ssl-dhparams.pem;
+
+    root  /var/www/docs.amis.institute;
+    index index.html;
+
+    # Docsify is a single-page app — all routes must resolve to index.html
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Cache static vendor assets aggressively (docsify JS/CSS)
+    location /vendor/ {
+        expires 30d;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # Security headers
+    add_header X-Frame-Options       "SAMEORIGIN"   always;
+    add_header X-Content-Type-Options "nosniff"     always;
+    add_header Referrer-Policy       "strict-origin" always;
+
+    access_log /var/log/nginx/docs.amis.institute.access.log;
+    error_log  /var/log/nginx/docs.amis.institute.error.log;
+}


### PR DESCRIPTION
## Changes

### 1. POST /users 400 fix
`CreateUserSchema` had `password: z.string().min(1)` (required), but the admin invite form never sends a password — it sends email + role and expects a welcome-email setup link. Made `password` optional; when omitted the API auto-generates a secure random placeholder.

### 2. Healthcheck localhost → 127.0.0.1
Alpine's `wget` resolves `localhost` to IPv6 `::1`, but Node.js listens on IPv4 `0.0.0.0`. Fixed in all 4 compose files: `docker-compose.staging.yml`, `docker-compose.prod.yml`, `docker-compose.offline.yml`, `install-kit/config/docker-compose.offline.yml`.

Closes #161