### PR TITLE
fix(onboarding): send contact verification + admin welcome email on provision

### DIFF
--- a/apps/api/src/modules/onboarding/onboarding.routes.ts
+++ b/apps/api/src/modules/onboarding/onboarding.routes.ts
@@ -16,8 +16,8 @@ import { pool } from "../../db/pool.js";
 import { hashPasswordAsync } from "../../lib/password.js";
 import { signToken } from "../../lib/jwt.js";
 import { requireRole } from "../../middleware/requireRole.js";
-import { randomBytes } from "crypto";
-import { createHash } from "crypto";
+import { randomBytes, createHash } from "crypto";
+import { sendMail, buildTenantVerificationEmail, buildWelcomeEmail } from "../../lib/email.js";
 
 // ------------------------------------------------------------------ helpers
 
@@ -242,13 +242,61 @@ export async function onboardingRoutes(app: FastifyInstance) {
         const tenantId: string = tenantRes.rows[0].id;
 
         const passwordHash = await hashPasswordAsync(tempPassword);
-        await client.query(
+        const userRes = await client.query(
           `INSERT INTO platform.users (tenant_id, email, password_hash, role, is_active)
-           VALUES ($1, $2, $3, 'admin', true)`,
+           VALUES ($1, $2, $3, 'admin', true)
+           RETURNING id`,
           [tenantId, adminEmail, passwordHash],
         );
+        const userId: string = userRes.rows[0].id;
 
         await client.query("COMMIT");
+
+        // Send contact email verification (outside transaction — non-fatal if it fails)
+        try {
+          const verifyToken = randomBytes(32).toString("hex");
+          const verifyHash = createHash("sha256").update(verifyToken).digest("hex");
+          const verifyExpiry = new Date(Date.now() + 72 * 60 * 60 * 1000); // 72 h
+          await pool.query(
+            `INSERT INTO platform.tenant_email_verifications (tenant_id, email, token_hash, expires_at)
+             VALUES ($1, $2, $3, $4)`,
+            [tenantId, contactEmail, verifyHash, verifyExpiry],
+          );
+          const appUrl = process.env.APP_URL ?? "http://localhost:5173";
+          const verifyUrl = `${appUrl}/verify-tenant-email?token=${verifyToken}`;
+          const { html, text } = buildTenantVerificationEmail(instituteName, verifyUrl);
+          await sendMail({
+            to: contactEmail,
+            subject: `Verify Contact Email for ${instituteName} — AMIS`,
+            html,
+            text,
+          });
+        } catch (emailErr) {
+          console.error("[onboarding] Contact email verification send failed:", emailErr);
+        }
+
+        // Send welcome / account-setup email to the admin user
+        try {
+          const setupToken = randomBytes(32).toString("hex");
+          const setupHash = createHash("sha256").update(setupToken).digest("hex");
+          const setupExpiry = new Date(Date.now() + 48 * 60 * 60 * 1000); // 48 h
+          await pool.query(
+            `INSERT INTO platform.password_reset_tokens (user_id, token_hash, expires_at)
+             VALUES ($1, $2, $3)`,
+            [userId, setupHash, setupExpiry],
+          );
+          const appUrl = process.env.APP_URL ?? "http://localhost:5173";
+          const setupUrl = `${appUrl}/reset-password?token=${setupToken}&mode=setup`;
+          const { html, text } = buildWelcomeEmail(setupUrl, null);
+          await sendMail({
+            to: adminEmail,
+            subject: "Welcome to AMIS — Set Up Your Account",
+            html,
+            text,
+          });
+        } catch (emailErr) {
+          console.error("[onboarding] Welcome email send failed:", emailErr);
+        }
 
         return reply.status(201).send({
           message: "VTI provisioned successfully",


### PR DESCRIPTION
## Problem

`POST /onboarding/provision` creates the tenant and admin user atomically but had **zero email sending logic**. This meant:

- The contact email (`demovti@amis.institute`) never received a tenant email verification email
- The admin user never received a welcome / set-up-your-password email

This was confirmed by checking the staging API logs: the request at `time:1779433980249` hit `/onboarding/provision` successfully, but no email was ever dispatched.

Root cause: PR #164 added email notifications to `POST /tenants` and `users.routes.ts`, but the provision pathway was overlooked.

## Fix

In `onboarding.routes.ts`, after the database `COMMIT`:

1. **Contact email verification** — generates a 72-hour token, inserts it into `platform.tenant_email_verifications`, and sends `buildTenantVerificationEmail` to `contactEmail`.
2. **Admin welcome email** — generates a 48-hour token, inserts it into `platform.password_reset_tokens`, and sends `buildWelcomeEmail` to `adminEmail` with a `?mode=setup` link.

Both blocks are wrapped in `try/catch` so failures are logged but **do not roll back the tenant creation** (matching the pattern in `tenants.routes.ts` and `users.routes.ts`).

Also changed the admin user `INSERT` to `RETURNING id` so we have `userId` available for the password reset token.

## Testing

- TypeScript compiles clean (`pnpm tsc --noEmit` exits 0)
- After deploy to staging, provision a test tenant and confirm both emails arrive