### PR TITLE
fix(auth): exempt GET /tenants/verify-email from requireAuth

### DIFF
--- a/apps/api/src/middleware/requireAuth.ts
+++ b/apps/api/src/middleware/requireAuth.ts
@@ -25,6 +25,7 @@ const PUBLIC_PATHS = new Set([
   "GET /auth/tenant-info",
   "GET /health",
   "POST /onboarding", // VTI self-registration is public
+  "GET /tenants/verify-email", // contact email verification link (public)
 ]);
 
 /** Route prefixes that never require authentication. */


### PR DESCRIPTION
## Problem
The tenant contact email verification link (`GET /tenants/verify-email?token=...`) is clicked by an unauthenticated user from their email client. The global `requireAuth` onRequest hook in `app.ts` was blocking it with `401 Authentication required` before the handler was reached.

## Fix
Add `GET /tenants/verify-email` to the `PUBLIC_PATHS` set in `requireAuth.ts`, alongside the other public routes (`/health`, `/auth/login`, `/onboarding`, etc.).

## Testing
After deploy: `curl https://api.pre.amis.institute/tenants/verify-email?token=<valid-token>` should return `200` or `{"message":"Already verified"}` instead of `401`.