### PR TITLE
fix: tenant delete RLS leak, cascade trigger & platform admin access

### DIFF
--- a/apps/api/src/modules/platform/platform.routes.ts
+++ b/apps/api/src/modules/platform/platform.routes.ts
@@ -4,7 +4,7 @@
  * GET /platform/users  — list all platform admin users (platform_admin only)
  */
 import type { FastifyInstance } from "fastify";
-import { pool } from "../../db/pool.js";
+import { superPool } from "../../db/pool.js";
 import { requireRole } from "../../middleware/requireRole.js";
 
 export async function platformRoutes(app: FastifyInstance) {
@@ -17,7 +17,7 @@ export async function platformRoutes(app: FastifyInstance) {
     "/platform/users",
     { preHandler: requireRole("platform_admin") },
     async (_req, reply) => {
-      const { rows } = await pool.query<{
+      const { rows } = await superPool.query<{
         id: string;
         email: string;
         role: string;

--- a/apps/api/src/modules/tenants/tenants.routes.ts
+++ b/apps/api/src/modules/tenants/tenants.routes.ts
@@ -71,7 +71,7 @@ const TenantsQuerySchema = z.object({
     .string()
     .optional()
     .transform((v) => (v ? parseInt(v, 10) : 20))
-    .pipe(z.number().int().min(1).max(100).default(20)),
+    .pipe(z.number().int().min(1).max(500).default(20)),
 });
 
 // ------------------------------------------------------------------ types
@@ -442,10 +442,29 @@ export async function tenantsRoutes(app: FastifyInstance) {
       // cascades correctly through RLS-protected tables (amis_app is subject to
       // RLS; without a tenant context set, cascade deletes would be blocked by the
       // RLS USING policy and cause a FK constraint violation → 500).
-      const result = await superPool.query(
-        `DELETE FROM platform.tenants WHERE id = $1 RETURNING id`,
-        [id],
-      );
+      //
+      // app.workflow_events has an append-only BEFORE trigger that blocks DELETE.
+      // We temporarily disable it (requires superuser) within a transaction so the
+      // CASCADE can remove workflow_events rows belonging to this tenant.
+      const client = await superPool.connect();
+      let result: { rows: { id: string }[] };
+      try {
+        await client.query("BEGIN");
+        await client.query("ALTER TABLE app.workflow_events DISABLE TRIGGER ALL");
+        result = await client.query(
+          `DELETE FROM platform.tenants WHERE id = $1 RETURNING id`,
+          [id],
+        );
+        await client.query("ALTER TABLE app.workflow_events ENABLE TRIGGER ALL");
+        await client.query("COMMIT");
+      } catch (err) {
+        await client.query("ROLLBACK");
+        // Best-effort re-enable in case the DISABLE succeeded but DELETE failed
+        await client.query("ALTER TABLE app.workflow_events ENABLE TRIGGER ALL").catch(() => {});
+        throw err;
+      } finally {
+        client.release();
+      }
 
       if (result.rows.length === 0) {
         return reply.status(404).send({ statusCode: 404, message: "Tenant not found" });

--- a/apps/web/src/platform-admin/PlatformTenantManager.tsx
+++ b/apps/web/src/platform-admin/PlatformTenantManager.tsx
@@ -46,7 +46,7 @@ export function PlatformTenantManager() {
 
   const { data, isLoading, error: loadErr } = useQuery<TenantsResponse>({
     queryKey: ["platform/tenants"],
-    queryFn: () => apiFetch<TenantsResponse>("/tenants?limit=200"),
+    queryFn: () => apiFetch<TenantsResponse>("/tenants?limit=500"),
     staleTime: 30_000,
   });
 

--- a/db/migrations/20260522000070_amis_app_grants.sql
+++ b/db/migrations/20260522000070_amis_app_grants.sql
@@ -1,0 +1,47 @@
+-- migrate:up
+
+-- Migration 20260407000005 created amis_app and granted privileges only on
+-- the tables that existed at that time. Many tables have been added since
+-- (workflow engine, admissions, staff, fees, marks, etc.) and amis_app has
+-- no access to them. This migration:
+--   1. Re-encodes amis_app password as scram-sha-256 (pg_hba.conf requires
+--      scram-sha-256 for TCP connections; if the password was stored as MD5
+--      from a prior migration run, external authentication hangs/fails).
+--   2. Re-grants on ALL current tables in app + platform schemas.
+--   3. Grants USAGE on all sequences (needed for INSERT with serial/bigserial cols).
+--   4. Sets DEFAULT PRIVILEGES so any future table/sequence created by the
+--      migration runner (superuser) is automatically accessible to amis_app.
+
+-- 0. Reset password with explicit scram-sha-256 encoding so TCP connections work
+SET password_encryption = 'scram-sha-256';
+ALTER ROLE amis_app PASSWORD 'amis_dev';
+RESET password_encryption;
+
+-- 1. Current tables
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA app      TO amis_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA platform TO amis_app;
+
+-- 2. Current sequences
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA app      TO amis_app;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA platform TO amis_app;
+
+-- 3. Default privileges for future objects created by the superuser role
+--    that runs migrations (covers any new tables/sequences added later).
+ALTER DEFAULT PRIVILEGES IN SCHEMA app
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO amis_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA platform
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO amis_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA app
+  GRANT USAGE, SELECT ON SEQUENCES TO amis_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA platform
+  GRANT USAGE, SELECT ON SEQUENCES TO amis_app;
+
+-- migrate:down
+ALTER DEFAULT PRIVILEGES IN SCHEMA app      REVOKE SELECT, INSERT, UPDATE, DELETE ON TABLES FROM amis_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA platform REVOKE SELECT, INSERT, UPDATE, DELETE ON TABLES FROM amis_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA app      REVOKE USAGE, SELECT ON SEQUENCES FROM amis_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA platform REVOKE USAGE, SELECT ON SEQUENCES FROM amis_app;
+REVOKE SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA app      FROM amis_app;
+REVOKE SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA platform FROM amis_app;
+REVOKE USAGE, SELECT ON ALL SEQUENCES IN SCHEMA app      FROM amis_app;
+REVOKE USAGE, SELECT ON ALL SEQUENCES IN SCHEMA platform FROM amis_app;

--- a/db/migrations/20260523000071_fix_platform_admin_tenant_id.sql
+++ b/db/migrations/20260523000071_fix_platform_admin_tenant_id.sql
@@ -1,0 +1,20 @@
+-- migrate:up
+-- Platform admin users must always have tenant_id = NULL.
+-- This migration fixes any existing platform_admin rows that were
+-- incorrectly assigned a non-null tenant_id (e.g., created before
+-- migration 50 made the column nullable, or seeded with a tenant_id).
+-- Without this fix, deleting a VTI whose id matches a platform admin's
+-- tenant_id would cascade-delete the platform admin's user record.
+UPDATE platform.users
+SET tenant_id = NULL
+WHERE role = 'platform_admin'
+  AND tenant_id IS NOT NULL;
+
+-- Also add a CHECK constraint to enforce this invariant going forward.
+ALTER TABLE platform.users
+  ADD CONSTRAINT platform_admin_no_tenant
+    CHECK (role <> 'platform_admin' OR tenant_id IS NULL);
+
+-- migrate:down
+ALTER TABLE platform.users DROP CONSTRAINT IF EXISTS platform_admin_no_tenant;
+-- (cannot recover original tenant_id values)


### PR DESCRIPTION
## Summary

Hotfix for critical bugs discovered on staging when deleting VTI tenants.

### Bugs Fixed

**1. Platform admin loses access after deleting a VTI** (`c3f7142`, `a0a03bc`)
- Root cause: platform admin's `tenant_id` was non-null, pointing to a VTI. When that VTI was deleted, `ON DELETE CASCADE` removed the platform admin's user record.
- Fix: Migration 71 sets `tenant_id = NULL` for all `platform_admin` users and adds a CHECK constraint preventing it from being set again.

**2. `GET /platform/users` returned empty list** (`a0a03bc`)
- Root cause: `platform.routes.ts` used the `pool` (amis_app user, subject to RLS). Without a `tenant_id` session variable set, the RLS policy blocked all rows.
- Fix: Changed to `superPool` (postgres superuser, bypasses RLS).

**3. Tenant delete 500 — `workflow_events is append-only`** (`9f3a70e`)
- Root cause: `ON DELETE CASCADE` on `app.workflow_events.tenant_id` triggers the `deny_workflow_events_mutation()` BEFORE DELETE trigger, which always raises an exception.
- Fix: Wrap tenant deletion in a transaction that temporarily disables the trigger (`ALTER TABLE app.workflow_events DISABLE TRIGGER ALL`) before the CASCADE, then re-enables it after.

**4. `GET /tenants?limit=200` → 400** (`2573fad`)
- Root cause: API had `.max(100)` on the limit param; frontend requested 200.
- Fix: API cap raised to 500; frontend updated to request 500.

**5. amis_app grants missing after schema changes** (`a71ffdc`)
- Migration 70 re-grants all required permissions to the `amis_app` role and fixes password hashing to scram-sha-256.

### Migrations
- `20260522000069` — `ON DELETE CASCADE` on all FKs referencing `platform.tenants(id)`
- `20260522000070` — Re-grant amis_app permissions
- `20260523000071` — Fix platform admin `tenant_id = NULL` + CHECK constraint

### Staging Status
All migrations applied manually on staging. API and web containers rebuilt and verified working.