### PR TITLE
fix: UAT batch — course edit, grading scale, admission source, healthcheck, pool recovery

### DIFF
--- a/apps/api/src/db/pool.recovery.test.ts
+++ b/apps/api/src/db/pool.recovery.test.ts
@@ -1,0 +1,84 @@
+/**
+ * pool.recovery.test.ts
+ *
+ * Verifies that the pg-pool auto-recovery logic replaces a wedged pool
+ * (3 consecutive idle-client errors) without requiring a container restart.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import EventEmitter from "events";
+
+// ---------------------------------------------------------------------------
+// Lightweight mock for pg.Pool that lets us fire synthetic 'error' and
+// 'connect' events and observe whether end() was called.
+// ---------------------------------------------------------------------------
+class MockPool extends EventEmitter {
+  ended = false;
+  async end() {
+    this.ended = true;
+  }
+}
+
+// Capture pool instances created by createPool so tests can inspect them.
+const createdPools: MockPool[] = [];
+
+// Mock the pg module — hoisted by Vitest before any imports.
+vi.mock("pg", () => ({
+  default: {
+    Pool: vi.fn().mockImplementation(() => {
+      const p = new MockPool();
+      createdPools.push(p);
+      return p;
+    }),
+  },
+}));
+
+import { pool, _resetPoolForTesting } from "./pool.js";
+
+describe("pg-pool auto-recovery", () => {
+  beforeEach(() => {
+    // Clear captured instances and reset the lazy singleton.
+    createdPools.length = 0;
+    _resetPoolForTesting();
+  });
+
+  it("creates a new pool after 3 consecutive idle-client errors", () => {
+    // Trigger lazy init.
+    void (pool as unknown as { query: unknown }).query;
+
+    expect(createdPools).toHaveLength(1);
+    const first = createdPools[0];
+
+    // Fire 2 errors — should NOT reset yet.
+    first.emit("error", new Error("connection terminated"));
+    first.emit("error", new Error("connection terminated"));
+    expect(first.ended).toBe(false);
+    expect(createdPools).toHaveLength(1);
+
+    // Third error — triggers recovery.
+    first.emit("error", new Error("connection terminated"));
+    expect(first.ended).toBe(true);
+
+    // Next proxy access must create a fresh pool.
+    void (pool as unknown as { query: unknown }).query;
+    expect(createdPools).toHaveLength(2);
+  });
+
+  it("resets the consecutive-error counter on a successful connect", () => {
+    void (pool as unknown as { query: unknown }).query;
+    const first = createdPools[0];
+
+    // 2 errors then a successful connect — counter resets.
+    first.emit("error", new Error("connection terminated"));
+    first.emit("error", new Error("connection terminated"));
+    first.emit("connect");
+
+    // 2 more errors — still below threshold.
+    first.emit("error", new Error("connection terminated"));
+    first.emit("error", new Error("connection terminated"));
+    expect(first.ended).toBe(false);
+
+    // 3rd error since last reset triggers replacement.
+    first.emit("error", new Error("connection terminated"));
+    expect(first.ended).toBe(true);
+  });
+});

--- a/apps/api/src/db/pool.ts
+++ b/apps/api/src/db/pool.ts
@@ -29,9 +29,31 @@ function createPool(): pg.Pool {
   // Prevent unhandled 'error' events from crashing the process.
   // node-postgres emits this when an idle client has its connection dropped
   // by the server — the pool will discard the client and create a new one.
+  //
+  // Recovery: after RECOVERY_THRESHOLD consecutive idle-client errors the pool
+  // is considered wedged (all connections simultaneously stale).  We end it
+  // and clear _pool so the next request transparently creates a fresh pool —
+  // no container restart required.
+  const RECOVERY_THRESHOLD = 3;
+  let consecutiveErrors = 0;
+
   p.on("error", (err) => {
     console.error("[pg-pool] idle client error — will be discarded:", err.message);
+    consecutiveErrors++;
+    if (consecutiveErrors >= RECOVERY_THRESHOLD && _pool === p) {
+      consecutiveErrors = 0;
+      _pool = null;
+      console.error("[pg-pool] pool replaced after consecutive idle-client errors");
+      p.end().catch((e: Error) =>
+        console.error("[pg-pool] error ending stale pool:", e.message),
+      );
+    }
   });
+
+  p.on("connect", () => {
+    consecutiveErrors = 0;
+  });
+
   return p;
 }
 
@@ -82,6 +104,12 @@ export const superPool: pg.Pool = new Proxy({} as pg.Pool, {
     return (getSuperPool() as unknown as Record<string | symbol, unknown>)[prop];
   },
 });
+
+/** @internal — test-only; resets the lazy pool singleton so the next access creates a fresh pool. */
+export function _resetPoolForTesting(): void {
+  _pool = null;
+  _superPool = null;
+}
 
 // Keepalive ping every 5 minutes — prevents NAT/firewall from silently
 // dropping idle connections between the API and Postgres containers.

--- a/apps/web/src/admin-studio/GradingScaleEditor.tsx
+++ b/apps/web/src/admin-studio/GradingScaleEditor.tsx
@@ -100,7 +100,7 @@ export function GradingScaleEditor() {
 
   const updateScaleMut = useMutation({
     mutationFn: ({ id, body }: { id: string; body: object }) =>
-      apiFetch(`/grading-scales/${id}`, { method: "PUT", body: JSON.stringify(body) }),
+      apiFetch(`/grading-scales/${id}`, { method: "PATCH", body: JSON.stringify(body) }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["grading-scales"] });
       qc.invalidateQueries({ queryKey: ["grading-scale", selectedId] });
@@ -111,7 +111,7 @@ export function GradingScaleEditor() {
 
   const bulkMut = useMutation({
     mutationFn: (rows: object[]) =>
-      apiFetch(`/grading-scales/${selectedId}/boundaries/bulk`, { method: "POST", body: JSON.stringify(rows) }),
+      apiFetch(`/grading-scales/${selectedId}/boundaries`, { method: "POST", body: JSON.stringify(rows) }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["grading-scale", selectedId] });
       setBoundaryError(null);

--- a/apps/web/src/modules/courses/courses.api.ts
+++ b/apps/web/src/modules/courses/courses.api.ts
@@ -53,3 +53,19 @@ export function createCourse(body: CreateCourseBody): Promise<Course> {
 export function deleteCourse(id: string): Promise<void> {
   return apiFetch<void>(`/courses/${id}`, { method: "DELETE" });
 }
+
+export interface UpdateCourseBody {
+  code?: string;
+  title?: string;
+  credit_hours?: number;
+  course_type?: "theory" | "practical" | "both";
+  year_of_study?: number;
+  semester?: number;
+}
+
+export function updateCourse(id: string, body: UpdateCourseBody): Promise<Course> {
+  return apiFetch<Course>(`/courses/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  });
+}

--- a/apps/web/src/modules/programmes/ProgrammeDetailPage.tsx
+++ b/apps/web/src/modules/programmes/ProgrammeDetailPage.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { getProgramme, updateProgramme, deleteProgramme, type UpdateProgrammeBody } from "./programmes.api";
-import { listCourses, createCourse, deleteCourse, type CreateCourseBody } from "../courses/courses.api";
+import { listCourses, createCourse, deleteCourse, updateCourse, type CreateCourseBody, type UpdateCourseBody, type Course } from "../courses/courses.api";
 import { useConfig } from "../../app/ConfigProvider";
 import {
   ensureGlobalCss,
@@ -59,6 +59,11 @@ export function ProgrammeDetailPage() {
     course_type: "theory" | "practical" | "both"; year_of_study: string; semester: string;
   }>({ code: "", title: "", credit_hours: "3", course_type: "theory", year_of_study: "1", semester: "1" });
   const [courseError, setCourseError] = useState<string | null>(null);
+  const [editingCourseId, setEditingCourseId] = useState<string | null>(null);
+  const [editCourseForm, setEditCourseForm] = useState<{
+    code: string; title: string; credit_hours: string;
+    course_type: "theory" | "practical" | "both"; year_of_study: string; semester: string;
+  }>({ code: "", title: "", credit_hours: "3", course_type: "theory", year_of_study: "1", semester: "1" });
 
   const { data: programme, isLoading, error } = useQuery({
     queryKey: ["programmes", id],
@@ -104,6 +109,28 @@ export function ProgrammeDetailPage() {
     mutationFn: (courseId: string) => deleteCourse(courseId),
     onSuccess: () => qc.invalidateQueries({ queryKey: ["courses", id] }),
   });
+
+  const updateCourseMutation = useMutation({
+    mutationFn: ({ courseId, body }: { courseId: string; body: UpdateCourseBody }) => updateCourse(courseId, body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["courses", id] });
+      setEditingCourseId(null);
+      setCourseError(null);
+    },
+    onError: (err: Error) => setCourseError(err.message),
+  });
+
+  function startEditCourse(course: Course) {
+    setEditingCourseId(course.id);
+    setEditCourseForm({
+      code: course.code,
+      title: course.title,
+      credit_hours: course.credit_hours != null ? String(course.credit_hours) : "3",
+      course_type: course.course_type ?? "theory",
+      year_of_study: course.year_of_study != null ? String(course.year_of_study) : "1",
+      semester: course.semester != null ? String(course.semester) : "1",
+    });
+  }
 
   function startEdit() {
     setForm({
@@ -303,30 +330,95 @@ export function ProgrammeDetailPage() {
               </tr>
             </thead>
             <tbody>
-              {courses.map((course) => (
-                <tr key={course.id} style={{ borderBottom: `1px solid ${C.border}` }}>
-                  <td style={{ padding: "8px 10px", fontFamily: "monospace", color: C.primary }}>{course.code}</td>
-                  <td style={{ padding: "8px 10px" }}>{course.title}</td>
-                  <td style={{ padding: "8px 10px", textAlign: "center" }}>{course.year_of_study}</td>
-                  <td style={{ padding: "8px 10px", textAlign: "center" }}>{course.semester}</td>
-                  <td style={{ padding: "8px 10px", textAlign: "center" }}>{course.credit_hours}</td>
-                  <td style={{ padding: "8px 10px" }}>
-                    <Badge
-                      label={course.course_type ?? "theory"}
-                      color={course.course_type === "practical" ? "blue" : course.course_type === "both" ? "purple" : "gray"}
-                    />
-                  </td>
-                  <td style={{ padding: "8px 10px" }}>
-                    <button
-                      onClick={() => { if (confirm(`Remove "${course.code}"?`)) deleteCourseMutation.mutate(course.id); }}
-                      style={{ background: "none", border: "none", color: C.red, cursor: "pointer", fontSize: 12, padding: "2px 6px" }}
-                      title="Remove course"
-                    >
-                      Remove
-                    </button>
-                  </td>
-                </tr>
-              ))}
+              {courses.map((course) =>
+                editingCourseId === course.id ? (
+                  <tr key={course.id} style={{ borderBottom: `1px solid ${C.border}`, background: "#f0f9ff" }}>
+                    <td style={{ padding: "6px 8px" }}>
+                      <input style={{ ...inputCss, width: 80 }} value={editCourseForm.code}
+                        onChange={(e) => setEditCourseForm((f) => ({ ...f, code: e.target.value }))} />
+                    </td>
+                    <td style={{ padding: "6px 8px" }}>
+                      <input style={inputCss} value={editCourseForm.title}
+                        onChange={(e) => setEditCourseForm((f) => ({ ...f, title: e.target.value }))} />
+                    </td>
+                    <td style={{ padding: "6px 8px" }}>
+                      <input type="number" min={1} max={6} style={{ ...inputCss, width: 52 }} value={editCourseForm.year_of_study}
+                        onChange={(e) => setEditCourseForm((f) => ({ ...f, year_of_study: e.target.value }))} />
+                    </td>
+                    <td style={{ padding: "6px 8px" }}>
+                      <input type="number" min={1} max={3} style={{ ...inputCss, width: 52 }} value={editCourseForm.semester}
+                        onChange={(e) => setEditCourseForm((f) => ({ ...f, semester: e.target.value }))} />
+                    </td>
+                    <td style={{ padding: "6px 8px" }}>
+                      <input type="number" min={1} max={10} style={{ ...inputCss, width: 60 }} value={editCourseForm.credit_hours}
+                        onChange={(e) => setEditCourseForm((f) => ({ ...f, credit_hours: e.target.value }))} />
+                    </td>
+                    <td style={{ padding: "6px 8px" }}>
+                      <select style={selectCss} value={editCourseForm.course_type}
+                        onChange={(e) => setEditCourseForm((f) => ({ ...f, course_type: e.target.value as typeof f.course_type }))}>
+                        <option value="theory">Theory</option>
+                        <option value="practical">Practical</option>
+                        <option value="both">Both</option>
+                      </select>
+                    </td>
+                    <td style={{ padding: "6px 8px", whiteSpace: "nowrap" }}>
+                      <button
+                        onClick={() => updateCourseMutation.mutate({
+                          courseId: course.id,
+                          body: {
+                            code: editCourseForm.code,
+                            title: editCourseForm.title,
+                            credit_hours: Number(editCourseForm.credit_hours),
+                            course_type: editCourseForm.course_type,
+                            year_of_study: Number(editCourseForm.year_of_study),
+                            semester: Number(editCourseForm.semester),
+                          },
+                        })}
+                        disabled={updateCourseMutation.isPending}
+                        style={{ background: "none", border: "none", color: C.primary, cursor: "pointer", fontSize: 12, padding: "2px 6px", fontWeight: 600 }}
+                      >
+                        {updateCourseMutation.isPending ? "…" : "Save"}
+                      </button>
+                      <button
+                        onClick={() => { setEditingCourseId(null); setCourseError(null); }}
+                        style={{ background: "none", border: "none", color: C.textSecondary, cursor: "pointer", fontSize: 12, padding: "2px 6px" }}
+                      >
+                        Cancel
+                      </button>
+                    </td>
+                  </tr>
+                ) : (
+                  <tr key={course.id} style={{ borderBottom: `1px solid ${C.border}` }}>
+                    <td style={{ padding: "8px 10px", fontFamily: "monospace", color: C.primary }}>{course.code}</td>
+                    <td style={{ padding: "8px 10px" }}>{course.title}</td>
+                    <td style={{ padding: "8px 10px", textAlign: "center" }}>{course.year_of_study}</td>
+                    <td style={{ padding: "8px 10px", textAlign: "center" }}>{course.semester}</td>
+                    <td style={{ padding: "8px 10px", textAlign: "center" }}>{course.credit_hours}</td>
+                    <td style={{ padding: "8px 10px" }}>
+                      <Badge
+                        label={course.course_type ?? "theory"}
+                        color={course.course_type === "practical" ? "blue" : course.course_type === "both" ? "purple" : "gray"}
+                      />
+                    </td>
+                    <td style={{ padding: "8px 10px", whiteSpace: "nowrap" }}>
+                      <button
+                        onClick={() => startEditCourse(course)}
+                        style={{ background: "none", border: "none", color: C.primary, cursor: "pointer", fontSize: 12, padding: "2px 6px" }}
+                        title="Edit course"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        onClick={() => { if (confirm(`Remove "${course.code}"?`)) deleteCourseMutation.mutate(course.id); }}
+                        style={{ background: "none", border: "none", color: C.red, cursor: "pointer", fontSize: 12, padding: "2px 6px" }}
+                        title="Remove course"
+                      >
+                        Remove
+                      </button>
+                    </td>
+                  </tr>
+                )
+              )}
             </tbody>
           </table>
         )}

--- a/db/migrations/20260523000072_admission_applications_source.sql
+++ b/db/migrations/20260523000072_admission_applications_source.sql
@@ -1,0 +1,11 @@
+-- migrate:up
+-- Issue #174: Public portal POST /public/:slug/apply uses a `source` column
+-- that did not exist, causing every online application to fail with a DB error.
+-- Add the column with default 'manual' so existing staff-created rows keep the
+-- correct value and the public portal can write 'online'.
+ALTER TABLE app.admission_applications
+  ADD COLUMN IF NOT EXISTS source text NOT NULL DEFAULT 'manual';
+
+-- migrate:down
+ALTER TABLE app.admission_applications
+  DROP COLUMN IF EXISTS source;

--- a/docker-compose.offline.yml
+++ b/docker-compose.offline.yml
@@ -60,7 +60,7 @@ services:
       db:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3000/health || exit 1"]
+      test: ["CMD-SHELL", "node -e \"require('http').get('http://127.0.0.1:3000/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))\""]
       interval: 20s
       timeout: 5s
       retries: 5

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -40,7 +40,7 @@ services:
       db:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3000/health || exit 1"]
+      test: ["CMD-SHELL", "node -e \"require('http').get('http://127.0.0.1:3000/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))\""]
       interval: 20s
       timeout: 5s
       retries: 3

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -78,7 +78,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3000/health || exit 1"]
+      test: ["CMD-SHELL", "node -e \"require('http').get('http://127.0.0.1:3000/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))\""]
       interval: 20s
       timeout: 5s
       retries: 3

--- a/install-kit/config/docker-compose.offline.yml
+++ b/install-kit/config/docker-compose.offline.yml
@@ -38,7 +38,7 @@ services:
       db:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3000/health || exit 1"]
+      test: ["CMD-SHELL", "node -e \"require('http').get('http://127.0.0.1:3000/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))\""]
       interval: 20s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary

Batch fix for UAT issues reported on pre.amis.institute.

### Fixes

- **#171** — Add Edit button for courses in Programme Detail page
  - Added `updateCourse()` / `UpdateCourseBody` to `courses.api.ts`
  - Inline edit form in `ProgrammeDetailPage.tsx`

- **#172** — Closed as duplicate of #171

- **#173** — Grade boundaries save broken
  - `GradingScaleEditor.tsx`: changed PUT → PATCH, removed `/bulk` from boundaries URL

- **#174** — `POST /public/:slug/apply` returns 500
  - Migration `20260523000072_admission_applications_source.sql` adds `source text NOT NULL DEFAULT 'manual'` to `app.admission_applications`

- **#155** — Healthcheck fails (wget not in api image)
  - Replaced `wget` healthcheck with `node -e "require('http').get(...)"` in all 4 compose files (`docker-compose.prod.yml`, `docker-compose.staging.yml`, `docker-compose.offline.yml`, `install-kit/config/docker-compose.offline.yml`)

- **#156, #157, #158** — Closed as duplicates of #155

- **#159** — pg-pool enters wedged state on simultaneous idle-client errors
  - `pool.ts`: auto-recovery after `RECOVERY_THRESHOLD` (3) consecutive idle-client errors — old pool is ended and `_pool` reset to null; next request creates a fresh pool transparently
  - Added `_resetPoolForTesting()` export
  - Unit tests: `src/db/pool.recovery.test.ts` — 2/2 pass

## Testing

All existing tests pass. New unit tests for pool recovery: 2/2 pass.

After merging, the staging deployment will require running the new migration:
```
dbmate up
```