### PR TITLE
fix(seed): add demovti tenant so public portal accepts applications (#176)

### DIFF
--- a/apps/api/src/modules/public/public.test.ts
+++ b/apps/api/src/modules/public/public.test.ts
@@ -92,6 +92,39 @@ describe("POST /public/:tenantSlug/apply", () => {
     expect(body.application.first_name).toBe("Jane");
     expect(body.application.programme).toBe("Nursing");
   });
+
+  it("inserts source='online' for public portal submissions", async () => {
+    // Regression for issue #176 — the INSERT must include source='online'
+    // so online applications are distinguishable from staff-created ones.
+    stubSlugLookup(true);
+    let capturedSql = "";
+    mockWithTenant.mockImplementation(async (_tid, cb) => {
+      const mockClient = {
+        query: vi.fn().mockImplementation((sql: string) => {
+          capturedSql = sql;
+          return Promise.resolve({
+            rows: [{
+              id: APP_ID,
+              first_name: "Jane",
+              last_name: "Doe",
+              programme: "Nursing",
+              intake: "2026-Sept",
+              created_at: new Date().toISOString(),
+            }],
+          });
+        }),
+      };
+      return cb(mockClient as never);
+    });
+
+    const app = buildApp();
+    await app.inject({
+      method: "POST",
+      url: "/public/demo-school/apply",
+      payload: validBody,
+    });
+    expect(capturedSql).toContain("'online'");
+  });
 });
 
 // ------------------------------------------------------------------ GET /public/:tenantSlug/applications/:id/status

--- a/db/seeds/seed.ts
+++ b/db/seeds/seed.ts
@@ -58,12 +58,22 @@ async function seed() {
        ON CONFLICT (slug) DO UPDATE SET name = EXCLUDED.name
        RETURNING id`,
     );
+    // Issue #176: demovti tenant must exist so the public portal can accept applications.
+    // This tenant is used for UAT/staging testing of the public application form.
+    const tenantC = await client.query<{ id: string }>(
+      `INSERT INTO platform.tenants (id, slug, name)
+       VALUES ('de000000-0000-0000-0000-000000000003', 'demovti', 'Demo Vocational Training Institute')
+       ON CONFLICT (slug) DO UPDATE SET name = EXCLUDED.name
+       RETURNING id`,
+    );
 
     const idA = tenantA.rows[0].id;
     const idB = tenantB.rows[0].id;
+    const idC = tenantC.rows[0].id;
 
     console.log(`Tenant A (Greenfield VTI):        ${idA}`);
     console.log(`Tenant B (Riverside Tech College): ${idB}`);
+    console.log(`Tenant C (Demo VTI):               ${idC}`);
 
     // Seed students for Tenant A
     await withTenant(client, idA, async () => {
@@ -122,6 +132,32 @@ async function seed() {
         [idB],
       );
       console.log("Seeded 5 programmes for Tenant B");
+    });
+
+    // Seed students for Tenant C (Demo VTI)
+    await withTenant(client, idC, async () => {
+      await client.query(
+        `INSERT INTO app.students (tenant_id, first_name, last_name, date_of_birth)
+         VALUES ($1, 'Amara', 'Osei',    '2004-05-20'),
+                ($1, 'Kwame', 'Boateng', '2003-11-03')
+         ON CONFLICT DO NOTHING`,
+        [idC],
+      );
+      console.log("Seeded 2 students for Tenant C");
+    });
+
+    // Seed programmes for Tenant C (Demo VTI)
+    await withTenant(client, idC, async () => {
+      await client.query(
+        `INSERT INTO app.programmes (tenant_id, code, title, department, duration_months, level, is_active)
+         VALUES
+           ($1, 'NCBC', 'National Certificate in Business Computing',   'Business & ICT', 12, 'National Certificate', true),
+           ($1, 'NCES', 'National Certificate in Electrical Systems',   'Engineering',    24, 'National Certificate', true),
+           ($1, 'NCAM', 'National Certificate in Automotive Mechanics', 'Engineering',    24, 'National Certificate', true)
+         ON CONFLICT (tenant_id, code) DO NOTHING`,
+        [idC],
+      );
+      console.log("Seeded 3 programmes for Tenant C");
     });
 
     // Seed staff for Tenant A (Greenfield VTI)
@@ -735,7 +771,7 @@ async function seed() {
     // IDs can be inserted cleanly.
     await client.query(
       `DELETE FROM platform.users
-       WHERE email LIKE '%@greenfield.test' OR email LIKE '%@riverside.test'`,
+       WHERE email LIKE '%@greenfield.test' OR email LIKE '%@riverside.test' OR email LIKE '%@demovti.test'`,
     );
 
     const devUsers: Array<{
@@ -756,6 +792,12 @@ async function seed() {
         email: `${role}@tenant-b.test`,
         role,
       })),
+      ...ROLES.map(({ role, idSuffix }) => ({
+        id: `00000000-0000-0000-0000-00000000002${idSuffix}`,
+        tenantId: idC,
+        email: `${role}@demovti.test`,
+        role,
+      })),
     ];
 
     for (const u of devUsers) {
@@ -771,7 +813,7 @@ async function seed() {
       );
     }
     console.log(
-      `Seeded ${devUsers.length} dev users (7 roles × 2 tenants, password: ${DEV_PASSWORD})`,
+      `Seeded ${devUsers.length} dev users (9 roles × 3 tenants, password: ${DEV_PASSWORD})`,
     );
 
     // Seed one platform_admin — no tenant_id (platform admins are cross-tenant)


### PR DESCRIPTION
## Summary

Fixes #176.

**Root cause**: The `demovti` tenant was never added to the dev/staging seed file. When the staging database was re-seeded, `demovti` was absent from `platform.tenants`, so `resolveTenantSlug('demovti')` returned `null` and every `POST /public/demovti/apply` request returned 404.

**Fix**:
- `db/seeds/seed.ts` — adds Tenant C (`demovti` / "Demo Vocational Training Institute") with:
  - Tenant row (UUID `de000000-0000-0000-0000-000000000003`)
  - 2 seed students
  - 3 seed programmes (NCBC, NCES, NCAM)
  - 9 dev users (`{role}@demovti.test`)
- `apps/api/src/modules/public/public.test.ts` — adds regression test verifying that `source='online'` is included in the INSERT SQL.

**No route/schema changes needed** — the code in `public.routes.ts` and the `source` column migration (000072, merged in #175) are already correct.

## Deployment steps for staging

1. `git pull` on VPS
2. `dbmate up` — applies migration 000072 (`source` column, idempotent `IF NOT EXISTS`)
3. Re-run seed: `DATABASE_URL=... npx tsx db/seeds/seed.ts`
4. Restart API: `docker compose -f docker-compose.staging.yml up -d --build api`
5. Smoke test:
```bash
curl -X POST https://api.pre.amis.institute/public/demovti/apply \
  -H 'Content-Type: application/json' \
  -d '{"first_name":"Test","last_name":"User","programme":"NCBC","intake":"2026-Sept","email":"test@example.com"}'
# expect 201
```

## Tests

All 7 tests in `public.test.ts` pass, including the new regression test.
