### PR TITLE
fix(db): seed demovti tenant migration so staging public portal resolves slug

### DIFF
--- a/db/migrations/20260524000073_seed_demovti_tenant.sql
+++ b/db/migrations/20260524000073_seed_demovti_tenant.sql
@@ -1,0 +1,16 @@
+-- migrate:up
+-- Ensure the demovti tenant exists for UAT / staging public portal testing.
+-- The public application form at /apply/demovti requires this slug to resolve.
+-- Uses ON CONFLICT DO NOTHING so this is safe to run on any environment.
+
+INSERT INTO platform.tenants (id, slug, name, is_active)
+VALUES (
+  'de000000-0000-0000-0000-000000000003',
+  'demovti',
+  'Demo Vocational Training Institute',
+  true
+)
+ON CONFLICT (slug) DO NOTHING;
+
+-- migrate:down
+DELETE FROM platform.tenants WHERE slug = 'demovti';


### PR DESCRIPTION
Adds migration 20260524000073_seed_demovti_tenant.sql to the repo.

This was an untracked local file. The migration inserts the demovti tenant with a fixed UUID using ON CONFLICT (slug) DO NOTHING, so it is safe to run on any environment.

Once merged, run dbmate up on staging to apply it.

Closes #178 (partial — error message UX remains open)