### PR TITLE
fix(admissions): rename DEFAULT_WORKFLOWS key admission→admissions, state accepted→admitted

### DIFF
--- a/apps/api/src/lib/workflowDef.test.ts
+++ b/apps/api/src/lib/workflowDef.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { DEFAULT_WORKFLOWS } from "./workflowDef.js";
+
+// Regression test for GitHub issue #180:
+// DEFAULT_WORKFLOWS used key "admission" (singular) while all application code
+// and the workflow engine use "admissions" (plural). This caused GET /workflows/admissions
+// to return 404, preventing workflow transitions and enrollment.
+
+describe("DEFAULT_WORKFLOWS", () => {
+  describe("admissions workflow", () => {
+    it('has an "admissions" key (plural)', () => {
+      expect(DEFAULT_WORKFLOWS).toHaveProperty("admissions");
+    });
+
+    it('does not have an "admission" key (singular) — regression guard', () => {
+      expect(DEFAULT_WORKFLOWS).not.toHaveProperty("admission");
+    });
+
+    it('has key field set to "admissions"', () => {
+      expect(DEFAULT_WORKFLOWS.admissions.key).toBe("admissions");
+    });
+
+    it('initial_state is "submitted"', () => {
+      expect(DEFAULT_WORKFLOWS.admissions.initial_state).toBe("submitted");
+    });
+
+    it('includes "admitted" state to allow enrollment', () => {
+      expect(DEFAULT_WORKFLOWS.admissions.states).toContain("admitted");
+    });
+
+    it('does not include "accepted" state (renamed to "admitted")', () => {
+      expect(DEFAULT_WORKFLOWS.admissions.states).not.toContain("accepted");
+    });
+
+    it('has a transition that leads to "admitted" state', () => {
+      const toAdmitted = DEFAULT_WORKFLOWS.admissions.transitions.find(
+        (t) => t.to === "admitted",
+      );
+      expect(toAdmitted).toBeDefined();
+    });
+
+    it('includes "rejected" state', () => {
+      expect(DEFAULT_WORKFLOWS.admissions.states).toContain("rejected");
+    });
+  });
+});

--- a/apps/api/src/lib/workflowDef.ts
+++ b/apps/api/src/lib/workflowDef.ts
@@ -66,14 +66,14 @@ export const DEFAULT_WORKFLOWS: Record<string, WorkflowDefinition> = {
       { action: "publish", from: "APPROVED", to: "PUBLISHED", required_role: "registrar" },
     ],
   },
-  admission: {
-    key: "admission",
+  admissions: {
+    key: "admissions",
     initial_state: "submitted",
-    states: ["submitted", "shortlisted", "interview", "accepted", "rejected"],
+    states: ["submitted", "shortlisted", "interview", "admitted", "rejected"],
     transitions: [
       { action: "shortlist", from: "submitted", to: "shortlisted", required_role: "registrar" },
       { action: "interview", from: "shortlisted", to: "interview", required_role: "registrar" },
-      { action: "accept", from: "interview", to: "accepted", required_role: "principal" },
+      { action: "admit", from: "interview", to: "admitted", required_role: "principal" },
       { action: "reject", from: "interview", to: "rejected", required_role: "principal" },
     ],
   },

--- a/apps/api/src/modules/admissions/admissions.routes.ts
+++ b/apps/api/src/modules/admissions/admissions.routes.ts
@@ -405,7 +405,7 @@ export async function admissionsRoutes(app: FastifyInstance) {
 
         // Check workflow state allows enrollment
         const state = application.current_state;
-        if (state !== "enrolled" && state !== "admitted") {
+        if (state !== "enrolled" && state !== "admitted" && state !== "accepted") {
           return {
             invalidState: true,
             message: `Cannot enroll: application is in "${state}" state`,


### PR DESCRIPTION
Fixes #180

## Root Cause

Two connected bugs in `apps/api/src/lib/workflowDef.ts` caused the 422 on Enrol as Student.

### Bug 1 — Workflow key mismatch (primary)
`DEFAULT_WORKFLOWS` defined the admissions workflow under key `"admission"` (singular), but every consumer — routes, workflow engine, frontend — calls `loadWorkflowDef(tid, "admissions", ...)` with the **plural** key. Result: `DEFAULT_WORKFLOWS["admissions"]` → `undefined` → `null` → `GET /workflows/admissions` returned **404**. The frontend received no workflow definition, rendered no transition buttons, and the registrar could never advance an application past `submitted`.

### Bug 2 — State name mismatch (secondary)
The enrol guard (added in commit `3f897be`) checks `state !== "admitted"`, but the default admissions workflow's terminal accepted state was `"accepted"` — so even if a tenant had a published config with the right key, enrollment would still 422.

## Changes

| File | Change |
|------|--------|
| `apps/api/src/lib/workflowDef.ts` | Renamed key `"admission"` → `"admissions"`, state `"accepted"` → `"admitted"`, action `"accept"` → `"admit"` |
| `apps/api/src/modules/admissions/admissions.routes.ts` | Enrol guard now also allows `state === "accepted"` for backward compat with any existing applications at that state |
| `apps/api/src/lib/workflowDef.test.ts` | New regression test file (8 tests) asserting `DEFAULT_WORKFLOWS` has the correct key and state names |

## Testing

All tests pass (exit code 0):

```
✓ apps/api/src/lib/workflowDef.test.ts (8)
✓ apps/api/src/modules/admissions/admissions.test.ts (6)
... (full suite)
```

## Re-test on Staging

1. Log in as Registrar → Admissions → open an application in `submitted` state
2. Confirm workflow buttons (Shortlist, Interview, Admit) are visible
3. Advance: `submitted → shortlisted → interview → admitted`
4. Click **Enrol as Student**, fill the modal, confirm → should return 201 (no 422)