### PR TITLE
fix(admissions): backfill workflow_instances for apps without one

### DIFF
--- a/db/migrations/20260525000074_backfill_admission_workflow_instances.sql
+++ b/db/migrations/20260525000074_backfill_admission_workflow_instances.sql
@@ -1,0 +1,47 @@
+-- migrate:up
+
+-- Backfill workflow_instances for admission_applications that have none.
+-- These are applications that were inserted directly into the DB (bypassing
+-- the API route that normally creates a workflow_instance atomically), or
+-- were created before the workflow engine was wired in.
+-- We set them to ADMITTED — the initial state of the reporting-day workflow.
+
+INSERT INTO app.workflow_instances
+  (tenant_id, entity_type, entity_id, workflow_key, current_state)
+SELECT
+  a.tenant_id,
+  'admissions',
+  a.id,
+  'admissions',
+  'ADMITTED'
+FROM app.admission_applications a
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM app.workflow_instances wi
+  WHERE wi.entity_type = 'admissions'
+    AND wi.entity_id = a.id
+);
+
+-- Write a synthetic audit event for each row we just inserted.
+INSERT INTO app.workflow_events
+  (tenant_id, entity_type, entity_id, workflow_key, from_state, to_state, action_key, actor_user_id)
+SELECT
+  wi.tenant_id,
+  wi.entity_type,
+  wi.entity_id,
+  wi.workflow_key,
+  NULL,
+  wi.current_state,
+  '__backfill_20260525__',
+  NULL
+FROM app.workflow_instances wi
+WHERE wi.workflow_key = 'admissions'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM app.workflow_events we
+    WHERE we.entity_id = wi.entity_id
+      AND we.workflow_key = 'admissions'
+  );
+
+-- migrate:down
+-- Intentionally left blank — do not delete application workflow state.


### PR DESCRIPTION
## Problem

Applications that were inserted directly into the DB (bypassing the POST /admissions/applications API route) have no workflow_instances row. When the enroll endpoint does a LEFT JOIN to workflow_instances, current_state comes back as NULL. NULL is not in enrollableStates, so the endpoint returns 422.

This is a third root cause of the enrollment 422 on staging, on top of the fixes in PR #181 and PR #182.

## Fix

Migration 20260525000074 backfills all dmission_applications that have no corresponding workflow_instances row, setting current_state = 'ADMITTED' (the initial state of the reporting-day workflow). A synthetic audit event is also written for traceability.

## Testing

After this migration runs on staging:
1. The 2 existing test applications (Simon, Mary) will have current_state = 'ADMITTED'
2. UAT testers must advance each application through: **Report In ? Clear Fees ? Register ? Enrol**
3. The Enrol step will succeed once the application reaches REGISTERED state

## Related

Closes the third root cause of issue #180 (already closed).