### PR TITLE
fix(migration): skip orphaned-tenant apps in workflow_instances backfill

### DIFF
--- a/db/migrations/20260525000074_backfill_admission_workflow_instances.sql
+++ b/db/migrations/20260525000074_backfill_admission_workflow_instances.sql
@@ -15,6 +15,7 @@ SELECT
   'admissions',
   'ADMITTED'
 FROM app.admission_applications a
+JOIN platform.tenants t ON t.id = a.tenant_id   -- skip orphaned apps whose tenant has been deleted
 WHERE NOT EXISTS (
   SELECT 1
   FROM app.workflow_instances wi


### PR DESCRIPTION
## Problem

Migration `20260525000074_backfill_admission_workflow_instances.sql` was failing on staging with:

```
Error: pq: insert or update on table "workflow_instances" violates foreign key constraint "workflow_instances_tenant_id_fkey"
```

The `admission_applications` table contained a row whose `tenant_id` (`0d60f314-eacb-4204-bf1c-fd2ee1a0cf0e`) no longer exists in `platform.tenants`. The original INSERT had no guard against orphaned apps, so the FK constraint fired.

## Fix

Added `JOIN platform.tenants t ON t.id = a.tenant_id` to the workflow_instances INSERT so that applications with a deleted/missing tenant are skipped silently.

## Staging status

The correct SQL was already applied manually on staging (Simon's app is `REGISTERED`). The migration version was recorded in `schema_migrations` by hand. This PR ensures future deployments (production, new staging instances, local dev) run the migration cleanly without errors.

Closes: related to #180