### PR TITLE
fix(web): omit Content-Type header for bodyless POST requests

### DIFF
--- a/apps/web/src/lib/apiFetch.ts
+++ b/apps/web/src/lib/apiFetch.ts
@@ -31,10 +31,16 @@ async function doFetch(
     ? { Authorization: `Bearer ${accessToken}`, "x-tenant-id": tenantId }
     : { "x-tenant-id": tenantId, "x-dev-role": devRole };
 
+  // Only send Content-Type: application/json when there is a body.
+  // Fastify 4 rejects requests that declare application/json but have an
+  // empty body (FST_ERR_CTP_EMPTY_JSON_BODY → 400).
+  const contentTypeHeader: Record<string, string> =
+    init?.body != null ? { "Content-Type": "application/json" } : {};
+
   return fetch(`${BASE_URL}${path}`, {
     ...init,
     headers: {
-      "Content-Type": "application/json",
+      ...contentTypeHeader,
       ...authHeaders,
       ...(init?.headers ?? {}),
     },


### PR DESCRIPTION
Fixes admissions import confirm failing with 400 error.

**Root Cause:** Fastify 4 returns 400 (FST_ERR_CTP_EMPTY_JSON_BODY) when a request declares Content-Type: application/json but sends an empty body. The confirmImport API call is a POST with no body, so doFetch was triggering this error before the route handler was reached.

**Solution:** Only emit Content-Type: application/json when init.body is present.

**Testing:** UAT Step 3C (bulk admissions import) should now complete successfully.