### PR TITLE
fix(admissions): restore enrolment workflow for imports

### DIFF
--- a/apps/api/src/lib/workflowDef.test.ts
+++ b/apps/api/src/lib/workflowDef.test.ts
@@ -20,27 +20,27 @@ describe("DEFAULT_WORKFLOWS", () => {
       expect(DEFAULT_WORKFLOWS.admissions.key).toBe("admissions");
     });
 
-    it('initial_state is "submitted"', () => {
-      expect(DEFAULT_WORKFLOWS.admissions.initial_state).toBe("submitted");
+    it('initial_state is "ADMITTED"', () => {
+      expect(DEFAULT_WORKFLOWS.admissions.initial_state).toBe("ADMITTED");
     });
 
-    it('includes "admitted" state to allow enrollment', () => {
-      expect(DEFAULT_WORKFLOWS.admissions.states).toContain("admitted");
+    it('includes "REGISTERED" state to allow enrollment', () => {
+      expect(DEFAULT_WORKFLOWS.admissions.states).toContain("REGISTERED");
     });
 
-    it('does not include "accepted" state (renamed to "admitted")', () => {
+    it('does not include legacy "accepted" state', () => {
       expect(DEFAULT_WORKFLOWS.admissions.states).not.toContain("accepted");
     });
 
-    it('has a transition that leads to "admitted" state', () => {
-      const toAdmitted = DEFAULT_WORKFLOWS.admissions.transitions.find(
-        (t) => t.to === "admitted",
+    it('has a transition that leads to "REGISTERED" state', () => {
+      const toRegistered = DEFAULT_WORKFLOWS.admissions.transitions.find(
+        (t) => t.to === "REGISTERED",
       );
-      expect(toAdmitted).toBeDefined();
+      expect(toRegistered).toBeDefined();
     });
 
-    it('includes "rejected" state', () => {
-      expect(DEFAULT_WORKFLOWS.admissions.states).toContain("rejected");
+    it('includes "WITHDRAWN" state', () => {
+      expect(DEFAULT_WORKFLOWS.admissions.states).toContain("WITHDRAWN");
     });
   });
 });

--- a/apps/api/src/lib/workflowDef.ts
+++ b/apps/api/src/lib/workflowDef.ts
@@ -68,13 +68,16 @@ export const DEFAULT_WORKFLOWS: Record<string, WorkflowDefinition> = {
   },
   admissions: {
     key: "admissions",
-    initial_state: "submitted",
-    states: ["submitted", "shortlisted", "interview", "admitted", "rejected"],
+    initial_state: "ADMITTED",
+    states: ["ADMITTED", "REPORTED", "FEE_CLEARED", "REGISTERED", "ENROLLED", "WITHDRAWN"],
     transitions: [
-      { action: "shortlist", from: "submitted", to: "shortlisted", required_role: "registrar" },
-      { action: "interview", from: "shortlisted", to: "interview", required_role: "registrar" },
-      { action: "admit", from: "interview", to: "admitted", required_role: "principal" },
-      { action: "reject", from: "interview", to: "rejected", required_role: "principal" },
+      { action: "report_in", from: "ADMITTED", to: "REPORTED", roles: ["registrar", "admin"], label: "Mark as Reported" },
+      { action: "clear_fees", from: "REPORTED", to: "FEE_CLEARED", roles: ["finance", "admin"], label: "Clear Fees" },
+      { action: "register", from: "FEE_CLEARED", to: "REGISTERED", roles: ["registrar", "admin"], label: "Issue ID & Register" },
+      { action: "enroll", from: "REGISTERED", to: "ENROLLED", roles: ["registrar", "admin"], label: "Enrol as Student" },
+      { action: "withdraw", from: "ADMITTED", to: "WITHDRAWN", roles: ["registrar", "admin"], label: "Withdraw" },
+      { action: "withdraw", from: "REPORTED", to: "WITHDRAWN", roles: ["registrar", "admin"], label: "Withdraw" },
+      { action: "withdraw", from: "FEE_CLEARED", to: "WITHDRAWN", roles: ["registrar", "admin"], label: "Withdraw" },
     ],
   },
   purchase_requisition: {

--- a/apps/api/src/modules/admissions/admissions.routes.ts
+++ b/apps/api/src/modules/admissions/admissions.routes.ts
@@ -111,7 +111,7 @@ export async function admissionsRoutes(app: FastifyInstance) {
   app.get(
     "/admissions/applications",
     {
-      preHandler: requireRole("admin", "registrar", "hod", "principal", "dean"),
+      preHandler: requireRole("admin", "registrar", "finance", "hod", "principal", "dean"),
     },
     async (req, reply) => {
       const tid = getTenantId(req);
@@ -175,7 +175,7 @@ export async function admissionsRoutes(app: FastifyInstance) {
   app.get<{ Params: { id: string } }>(
     "/admissions/applications/:id",
     {
-      preHandler: requireRole("admin", "registrar", "hod", "principal", "dean"),
+      preHandler: requireRole("admin", "registrar", "finance", "hod", "principal", "dean"),
     },
     async (req, reply) => {
       const tid = getTenantId(req);

--- a/apps/api/src/modules/admissions/admissions.test.ts
+++ b/apps/api/src/modules/admissions/admissions.test.ts
@@ -11,6 +11,7 @@ const mockWithTenant = vi.mocked(withTenant);
 const TID = "00000000-0000-0000-0000-000000000010";
 const headers = { "x-tenant-id": TID };
 const registrarHeaders = { "x-tenant-id": TID, "x-dev-role": "registrar" };
+const financeHeaders = { "x-tenant-id": TID, "x-dev-role": "finance" };
 const hodHeaders = { "x-tenant-id": TID, "x-dev-role": "hod" };
 
 beforeEach(() => vi.resetAllMocks());
@@ -147,6 +148,18 @@ describe("GET /admissions/applications", () => {
     expect(res.statusCode).toBe(200);
     expect(res.json()).toHaveLength(1);
   });
+
+  it("allows finance to list applications for fee clearance", async () => {
+    mockWithTenant.mockResolvedValueOnce({ rows: [fakeApplication] } as never);
+    const app = buildApp();
+    const res = await app.inject({
+      method: "GET",
+      url: "/admissions/applications?current_state=REPORTED",
+      headers: financeHeaders,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual([fakeApplication]);
+  });
 });
 
 // ------------------------------------------------------------------ GET /admissions/applications/:id
@@ -187,6 +200,18 @@ describe("GET /admissions/applications/:id", () => {
       id: fakeApplication.id,
       current_state: "submitted",
     });
+  });
+
+  it("allows finance to view an application for fee clearance", async () => {
+    mockWithTenant.mockResolvedValueOnce(fakeApplication as never);
+    const app = buildApp();
+    const res = await app.inject({
+      method: "GET",
+      url: `/admissions/applications/${fakeApplication.id}`,
+      headers: financeHeaders,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ id: fakeApplication.id });
   });
 });
 

--- a/apps/api/src/modules/workflow/workflow.routes.ts
+++ b/apps/api/src/modules/workflow/workflow.routes.ts
@@ -262,7 +262,7 @@ export async function workflowRoutes(app: FastifyInstance) {
   }>(
     "/workflow/:entityType/:entityId",
     {
-      preHandler: requireRole("admin", "registrar", "hod", "principal", "dean"),
+      preHandler: requireRole("admin", "registrar", "finance", "hod", "principal", "dean"),
     },
     async (req, reply) => {
       const tid = getTenantId(req);

--- a/apps/api/src/modules/workflow/workflow.test.ts
+++ b/apps/api/src/modules/workflow/workflow.test.ts
@@ -12,6 +12,7 @@ const TID = "00000000-0000-0000-0000-000000000001";
 const ENTITY_TYPE = "admission_application";
 const ENTITY_ID = "aaaaaaaa-0000-0000-0000-000000000001";
 const headers = { "x-tenant-id": TID };
+const financeHeaders = { "x-tenant-id": TID, "x-dev-role": "finance" };
 
 const BASE_URL = `/workflow/${ENTITY_TYPE}/${ENTITY_ID}`;
 
@@ -243,6 +244,17 @@ describe("GET /workflow/:entityType/:entityId", () => {
     mockWithTenant.mockResolvedValueOnce(fakeInstance as never);
     const app = makeApp();
     const res = await app.inject({ method: "GET", url: BASE_URL, headers });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      workflowKey: "admissions",
+      currentState: "submitted",
+    });
+  });
+
+  it("allows finance to read workflow state for fee-clearance queues", async () => {
+    mockWithTenant.mockResolvedValueOnce(fakeInstance as never);
+    const app = makeApp();
+    const res = await app.inject({ method: "GET", url: BASE_URL, headers: financeHeaders });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual({
       workflowKey: "admissions",

--- a/apps/web/src/app/AppShell.tsx
+++ b/apps/web/src/app/AppShell.tsx
@@ -135,7 +135,7 @@ const ROLE_FALLBACK_NAV: Record<string, string[]> = {
     "/marks", "/results", "/clearance", "/users",
   ],
   finance: [
-    "/", "/finance", "/finance/reconciliation", "/students",
+    "/", "/finance", "/finance/reconciliation", "/students", "/admissions",
   ],
   hod: [
     "/", "/marks", "/results", "/staff", "/timetable", "/attendance", "/clearance",

--- a/apps/web/src/modules/admissions/AdmissionsListPage.tsx
+++ b/apps/web/src/modules/admissions/AdmissionsListPage.tsx
@@ -18,6 +18,10 @@ import {
 } from "../../lib/ui";
 
 const ADMISSION_STATES = [
+  "ADMITTED",
+  "REPORTED",
+  "FEE_CLEARED",
+  "REGISTERED",
   "DRAFT",
   "SUBMITTED",
   "UNDER_REVIEW",
@@ -26,6 +30,7 @@ const ADMISSION_STATES = [
   "APPROVED_PRIVATE",
   "REJECTED",
   "ENROLLED",
+  "WITHDRAWN",
 ];
 
 type BadgeColor =
@@ -37,6 +42,10 @@ type BadgeColor =
   | "red"
   | "cyan";
 const STATE_BADGE: Record<string, BadgeColor> = {
+  ADMITTED: "blue",
+  REPORTED: "yellow",
+  FEE_CLEARED: "green",
+  REGISTERED: "purple",
   DRAFT: "gray",
   SUBMITTED: "blue",
   UNDER_REVIEW: "yellow",
@@ -45,6 +54,7 @@ const STATE_BADGE: Record<string, BadgeColor> = {
   APPROVED_PRIVATE: "green",
   REJECTED: "red",
   ENROLLED: "cyan",
+  WITHDRAWN: "red",
 };
 
 export function AdmissionsListPage() {

--- a/apps/web/src/modules/admissions/ApplicationDetailPage.tsx
+++ b/apps/web/src/modules/admissions/ApplicationDetailPage.tsx
@@ -40,6 +40,8 @@ const STATE_BADGE_COLOR: Record<
   ENROLLED: "cyan",
 };
 
+const ENROLLABLE_STATES = new Set(["REGISTERED", "admitted", "accepted", "ENROLLED", "enrolled"]);
+
 function formatExtKey(key: string): string {
   return key
     .replace(/_/g, " ")
@@ -413,6 +415,7 @@ export function ApplicationDetailPage() {
     );
 
   const currentState = app.current_state;
+  const canEnrol = ENROLLABLE_STATES.has(currentState);
   const myRole = user?.role ?? null;
   const superRoles = ["admin", "platform_admin"];
 
@@ -420,6 +423,7 @@ export function ApplicationDetailPage() {
   const availableTransitions = wfDef
     ? wfDef.transitions.filter((t) => {
         if (t.from !== currentState) return false;
+        if (t.action === "enroll") return false;
         // Roles array takes precedence; fall back to required_role string.
         const allowed: string[] | null =
           t.roles && t.roles.length > 0
@@ -503,7 +507,7 @@ export function ApplicationDetailPage() {
             View Student Record →
           </SecondaryBtn>
         </Card>
-      ) : (
+      ) : canEnrol ? (
         <Card
           padding="20px 24px"
           style={{
@@ -521,6 +525,16 @@ export function ApplicationDetailPage() {
           <PrimaryBtn onClick={() => setShowEnrolModal(true)}>
             🎓 Enrol as Student
           </PrimaryBtn>
+        </Card>
+      ) : (
+        <Card padding="20px 24px" style={{ marginBottom: 16 }}>
+          <SectionLabel>Enrol as Student</SectionLabel>
+          <p
+            style={{ fontSize: 14, color: "#6b7280", margin: 0 }}
+          >
+            Complete the available workflow actions until this application reaches
+            REGISTERED before creating the student record.
+          </p>
         </Card>
       )}
 

--- a/apps/web/src/modules/admissions/ApplicationDetailPage.tsx
+++ b/apps/web/src/modules/admissions/ApplicationDetailPage.tsx
@@ -30,6 +30,10 @@ const STATE_BADGE_COLOR: Record<
   string,
   "gray" | "blue" | "yellow" | "purple" | "green" | "red" | "cyan"
 > = {
+  ADMITTED: "blue",
+  REPORTED: "yellow",
+  FEE_CLEARED: "green",
+  REGISTERED: "purple",
   DRAFT: "gray",
   SUBMITTED: "blue",
   UNDER_REVIEW: "yellow",
@@ -38,6 +42,7 @@ const STATE_BADGE_COLOR: Record<
   APPROVED_PRIVATE: "green",
   REJECTED: "red",
   ENROLLED: "cyan",
+  WITHDRAWN: "red",
 };
 
 const ENROLLABLE_STATES = new Set(["REGISTERED", "admitted", "accepted", "ENROLLED", "enrolled"]);
@@ -415,7 +420,7 @@ export function ApplicationDetailPage() {
     );
 
   const currentState = app.current_state;
-  const canEnrol = ENROLLABLE_STATES.has(currentState);
+  const canEnrol = currentState !== null && ENROLLABLE_STATES.has(currentState);
   const myRole = user?.role ?? null;
   const superRoles = ["admin", "platform_admin"];
 

--- a/apps/web/src/modules/term-registrations/BulkRegistrationPage.tsx
+++ b/apps/web/src/modules/term-registrations/BulkRegistrationPage.tsx
@@ -31,14 +31,14 @@ function bulkRegister(body: {
   term: string;
   student_ids: string[];
 }) {
-  return apiFetch<{ registered: number; skipped: number }>(
+  return apiFetch<{ created: number; skipped: number; errors?: unknown[] }>(
     "/term-registrations/bulk",
     { method: "POST", body: JSON.stringify(body) },
   );
 }
 
-function promote(body: { academic_year: string; term: string }) {
-  return apiFetch<{ registered: number }>(
+function registerAllActive(body: { academic_year: string; term: string }) {
+  return apiFetch<{ created: number; total_active_students: number }>(
     "/term-registrations/promote",
     { method: "POST", body: JSON.stringify(body) },
   );
@@ -78,14 +78,15 @@ export function BulkRegistrationPage() {
           .filter(Boolean),
       }),
     onSuccess: (d) =>
-      setResult(`Registered: ${d.registered}, Skipped: ${d.skipped}`),
+      setResult(`Registered: ${d.created}, Skipped: ${d.skipped}`),
     onError: (e: Error) => setResult(`Error: ${e.message}`),
   });
 
-  const promoteMut = useMutation({
-    mutationFn: () => promote({ academic_year: academicYearName, term: selectedTermName }),
+  const registerAllMut = useMutation({
+    mutationFn: () =>
+      registerAllActive({ academic_year: academicYearName, term: selectedTermName }),
     onSuccess: (d) =>
-      setResult(`Auto-promoted ${d.registered} active students`),
+      setResult(`Registered ${d.created} active students for this term`),
     onError: (e: Error) => setResult(`Error: ${e.message}`),
   });
 
@@ -126,16 +127,16 @@ export function BulkRegistrationPage() {
           </select>
         </div>
 
-        <SectionLabel>Option 1: Promote All Active Students</SectionLabel>
+        <SectionLabel>Option 1: Register All Active Students</SectionLabel>
         <p style={{ fontSize: 13, color: C.textSecondary, marginBottom: 8 }}>
-          Auto-registers all active students who are not yet registered for this
+          Registers all active students who are not yet registered for this
           term.
         </p>
         <SecondaryBtn
-          onClick={() => promoteMut.mutate()}
-          disabled={!academicYearName || !selectedTermName || promoteMut.isPending}
+          onClick={() => registerAllMut.mutate()}
+          disabled={!academicYearName || !selectedTermName || registerAllMut.isPending}
         >
-          {promoteMut.isPending ? "Promoting…" : "Promote All Active"}
+          {registerAllMut.isPending ? "Registering…" : "Register All Active"}
         </SecondaryBtn>
       </Card>
 

--- a/db/migrations/20260526000075_admissions_workflow_config_backfill.sql
+++ b/db/migrations/20260526000075_admissions_workflow_config_backfill.sql
@@ -1,0 +1,98 @@
+-- migrate:up
+
+-- Ensure every published tenant config has the current admissions workflow.
+-- Some tenants had no payload.workflows.admissions entry, causing the API to
+-- fall back to the old built-in submitted/shortlisted/interview workflow.
+UPDATE platform.config_versions
+SET payload = jsonb_set(
+  jsonb_set(
+    COALESCE(payload, '{}'::jsonb),
+    '{workflows}',
+    COALESCE(payload->'workflows', '{}'::jsonb),
+    true
+  ),
+  '{workflows,admissions}',
+  '{
+    "key": "admissions",
+    "initial_state": "ADMITTED",
+    "states": [
+      "ADMITTED",
+      "REPORTED",
+      "FEE_CLEARED",
+      "REGISTERED",
+      "ENROLLED",
+      "WITHDRAWN"
+    ],
+    "transitions": [
+      {
+        "action": "report_in",
+        "from": "ADMITTED",
+        "to": "REPORTED",
+        "roles": ["registrar", "admin"],
+        "label": "Mark as Reported"
+      },
+      {
+        "action": "clear_fees",
+        "from": "REPORTED",
+        "to": "FEE_CLEARED",
+        "roles": ["finance", "admin"],
+        "label": "Clear Fees"
+      },
+      {
+        "action": "register",
+        "from": "FEE_CLEARED",
+        "to": "REGISTERED",
+        "roles": ["registrar", "admin"],
+        "label": "Issue ID & Register"
+      },
+      {
+        "action": "enroll",
+        "from": "REGISTERED",
+        "to": "ENROLLED",
+        "roles": ["registrar", "admin"],
+        "label": "Enrol as Student"
+      },
+      {
+        "action": "withdraw",
+        "from": "ADMITTED",
+        "to": "WITHDRAWN",
+        "roles": ["registrar", "admin"],
+        "label": "Withdraw"
+      },
+      {
+        "action": "withdraw",
+        "from": "REPORTED",
+        "to": "WITHDRAWN",
+        "roles": ["registrar", "admin"],
+        "label": "Withdraw"
+      },
+      {
+        "action": "withdraw",
+        "from": "FEE_CLEARED",
+        "to": "WITHDRAWN",
+        "roles": ["registrar", "admin"],
+        "label": "Withdraw"
+      }
+    ]
+  }'::jsonb,
+  true
+)
+WHERE status = 'published';
+
+-- Normalize any admissions created after the earlier workflow migration while
+-- the API was still using the old built-in fallback workflow.
+UPDATE app.workflow_instances
+SET current_state = CASE current_state
+  WHEN 'submitted'   THEN 'ADMITTED'
+  WHEN 'shortlisted' THEN 'ADMITTED'
+  WHEN 'interview'   THEN 'REPORTED'
+  WHEN 'accepted'    THEN 'REGISTERED'
+  WHEN 'admitted'    THEN 'REGISTERED'
+  WHEN 'rejected'    THEN 'WITHDRAWN'
+  ELSE current_state
+END
+WHERE workflow_key = 'admissions'
+  AND current_state IN ('submitted','shortlisted','interview','accepted','admitted','rejected');
+
+-- migrate:down
+-- Not reversible without losing workflow history.


### PR DESCRIPTION
## Summary
- updates the built-in admissions fallback workflow to the reporting-day ADMITTED -> REPORTED -> FEE_CLEARED -> REGISTERED -> ENROLLED flow
- backfills published tenant configs that were missing workflows.admissions and remaps legacy imported application states
- prevents the enrol modal from appearing before an application reaches an enrol-ready state

## Validation
- VS Code diagnostics: no errors in touched TS files
- Local Vitest unavailable: workspace dependencies missing (vitest not installed locally)