### PR TITLE
fix(academic-calendar): show real API error + handle constraints on create year

### DIFF
--- a/apps/api/src/modules/academic-calendar/academic-calendar.routes.ts
+++ b/apps/api/src/modules/academic-calendar/academic-calendar.routes.ts
@@ -114,23 +114,34 @@ export async function academicCalendarRoutes(app: FastifyInstance) {
 
       const { name, start_date, end_date, is_current } = parsed.data;
 
-      const row = await withTenant(tid, async (client) => {
-        if (is_current) {
-          await client.query(
-            `UPDATE app.academic_years SET is_current = false WHERE tenant_id = $1`,
-            [tid],
+      try {
+        const row = await withTenant(tid, async (client) => {
+          if (is_current) {
+            await client.query(
+              `UPDATE app.academic_years SET is_current = false WHERE tenant_id = $1`,
+              [tid],
+            );
+          }
+          return client.query(
+            `INSERT INTO app.academic_years
+               (tenant_id, name, start_date, end_date, is_current)
+             VALUES ($1, $2, $3, $4, $5)
+             RETURNING ${AY_COLS}`,
+            [tid, name, start_date, end_date, is_current ?? false],
           );
-        }
-        return client.query(
-          `INSERT INTO app.academic_years
-             (tenant_id, name, start_date, end_date, is_current)
-           VALUES ($1, $2, $3, $4, $5)
-           RETURNING ${AY_COLS}`,
-          [tid, name, start_date, end_date, is_current ?? false],
-        );
-      });
+        });
 
-      return reply.status(201).send(row.rows[0]);
+        return reply.status(201).send(row.rows[0]);
+      } catch (err: unknown) {
+        const pgCode = (err as { code?: string })?.code;
+        if (pgCode === "23505") {
+          return reply.status(409).send({ error: "An academic year with that name already exists for this tenant." });
+        }
+        if (pgCode === "23514") {
+          return reply.status(422).send({ error: "End date must be after start date." });
+        }
+        throw err;
+      }
     },
   );
 

--- a/apps/web/src/admin-studio/AcademicCalendarPage.tsx
+++ b/apps/web/src/admin-studio/AcademicCalendarPage.tsx
@@ -77,13 +77,13 @@ export function AcademicCalendarPage() {
   const createYearMut = useMutation({
     mutationFn: (body: object) => apiFetch("/academic-years", { method: "POST", body: JSON.stringify(body) }),
     onSuccess: () => { qc.invalidateQueries({ queryKey: ["academic-years"] }); setShowYearForm(false); resetYearForm(); setSuccessMsg("Academic year created."); },
-    onError: () => setYearError("Failed to create academic year"),
+    onError: (err: unknown) => setYearError(err instanceof ApiError && err.body && typeof err.body === "object" && "error" in err.body ? String((err.body as { error: unknown }).error) : "Failed to create academic year"),
   });
 
   const updateYearMut = useMutation({
     mutationFn: ({ id, body }: { id: string; body: object }) => apiFetch(`/academic-years/${id}`, { method: "PATCH", body: JSON.stringify(body) }),
     onSuccess: () => { qc.invalidateQueries({ queryKey: ["academic-years"] }); setEditYear(null); setSuccessMsg("Updated."); },
-    onError: () => setYearError("Failed to update"),
+    onError: (err: unknown) => setYearError(err instanceof ApiError && err.body && typeof err.body === "object" && "error" in err.body ? String((err.body as { error: unknown }).error) : "Failed to update"),
   });
 
   const createTermMut = useMutation({


### PR DESCRIPTION
## Problem

After merging #238, users may still see a generic "Failed to create academic year" with no indication of the actual failure reason. The `onError` handler discarded the error object, making it impossible to diagnose issues.

## Changes

### `AcademicCalendarPage.tsx`
- `createYearMut.onError` and `updateYearMut.onError` now extract and display the actual `error` field from the API response body instead of a hardcoded string.

### `academic-calendar.routes.ts`
- `POST /academic-years` now wraps the DB operation in `try/catch`:
  - `23505` (unique violation) ? 409 with descriptive message
  - `23514` (check constraint, e.g. end < start) ? 422 with descriptive message
  - Other errors re-thrown (Fastify returns 500)

## Diagnosis

If you are still seeing the error after deploying #238, this PR will surface the real reason (e.g. duplicate name, date range issue, or a 500 from the server).