### PR TITLE
Fix UAT bugs #215 and #204: Fee structure error visibility and marks workflow

### DIFF
--- a/apps/api/src/modules/fee-structures/fee-structures.routes.ts
+++ b/apps/api/src/modules/fee-structures/fee-structures.routes.ts
@@ -140,27 +140,36 @@ export async function feeStructuresRoutes(app: FastifyInstance) {
       const { academic_year_id, term_id, programme_id, fee_type, student_category, description, amount, currency } =
         parsed.data;
 
-      const row = await withTenant(tid, (client) =>
-        client.query(
-          `INSERT INTO app.fee_structures
-             (tenant_id, academic_year_id, term_id, programme_id, fee_type, student_category, description, amount, currency)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-           RETURNING ${FS_COLS}`,
-          [
-            tid,
-            academic_year_id,
-            term_id ?? null,
-            programme_id,
-            fee_type ?? "tuition",
-            student_category ?? "all",
-            description ?? null,
-            amount,
-            currency ?? "UGX",
-          ],
-        ),
-      );
+      try {
+        const row = await withTenant(tid, (client) =>
+          client.query(
+            `INSERT INTO app.fee_structures
+               (tenant_id, academic_year_id, term_id, programme_id, fee_type, student_category, description, amount, currency)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+             RETURNING ${FS_COLS}`,
+            [
+              tid,
+              academic_year_id,
+              term_id ?? null,
+              programme_id,
+              fee_type ?? "tuition",
+              student_category ?? "all",
+              description ?? null,
+              amount,
+              currency ?? "UGX",
+            ],
+          ),
+        );
 
-      return reply.status(201).send(row.rows[0]);
+        return reply.status(201).send(row.rows[0]);
+      } catch (err: any) {
+        if (err.code === "23505") {
+          return reply.status(409).send({
+            error: "A fee structure with this combination of academic year, term, programme, fee type, and student category already exists.",
+          });
+        }
+        throw err;
+      }
     },
   );
 
@@ -185,20 +194,29 @@ export async function feeStructuresRoutes(app: FastifyInstance) {
       const setClauses = fields.map((k, i) => `${k} = $${i + 2}`).join(", ");
       const values = fields.map((k) => updates[k]);
 
-      const row = await withTenant(tid, (client) =>
-        client.query(
-          `UPDATE app.fee_structures
-           SET ${setClauses}, updated_at = now()
-           WHERE id = $1
-           RETURNING ${FS_COLS}`,
-          [req.params.id, ...values],
-        ),
-      );
+      try {
+        const row = await withTenant(tid, (client) =>
+          client.query(
+            `UPDATE app.fee_structures
+             SET ${setClauses}, updated_at = now()
+             WHERE id = $1
+             RETURNING ${FS_COLS}`,
+            [req.params.id, ...values],
+          ),
+        );
 
-      if (row.rows.length === 0)
-        return reply.status(404).send({ error: "fee structure not found" });
+        if (row.rows.length === 0)
+          return reply.status(404).send({ error: "fee structure not found" });
 
-      return row.rows[0];
+        return row.rows[0];
+      } catch (err: any) {
+        if (err.code === "23505") {
+          return reply.status(409).send({
+            error: "A fee structure with this combination of academic year, term, programme, fee type, and student category already exists.",
+          });
+        }
+        throw err;
+      }
     },
   );
 }

--- a/apps/web/src/admin-studio/FeeStructureEditor.tsx
+++ b/apps/web/src/admin-studio/FeeStructureEditor.tsx
@@ -190,7 +190,7 @@ export function FeeStructureEditor() {
       programme_id: form.programme_id,
       fee_type: form.fee_type,
       student_category: form.student_category,
-      description: form.description || null,
+      description: form.description || undefined,
       amount: parseFloat(form.amount),
       currency: form.currency,
       is_active: form.is_active,

--- a/apps/web/src/admin-studio/FeeStructureEditor.tsx
+++ b/apps/web/src/admin-studio/FeeStructureEditor.tsx
@@ -121,11 +121,15 @@ export function FeeStructureEditor() {
       resetForm();
     },
     onError: (err) => {
+      console.error("Fee structure creation error:", err);
       let message = "Failed to create fee structure";
       if (err instanceof ApiError && err.body && typeof err.body === "object" && "error" in err.body) {
         const errorData = (err.body as { error: unknown }).error;
         message = typeof errorData === "string" ? errorData : JSON.stringify(errorData, null, 2);
+      } else if (err instanceof Error) {
+        message = err.message;
       }
+      console.log("Displaying error message:", message);
       setError(message);
     },
   });
@@ -141,11 +145,15 @@ export function FeeStructureEditor() {
       resetForm();
     },
     onError: (err) => {
+      console.error("Fee structure update error:", err);
       let message = "Failed to update fee structure";
       if (err instanceof ApiError && err.body && typeof err.body === "object" && "error" in err.body) {
         const errorData = (err.body as { error: unknown }).error;
         message = typeof errorData === "string" ? errorData : JSON.stringify(errorData, null, 2);
+      } else if (err instanceof Error) {
+        message = err.message;
       }
+      console.log("Displaying error message:", message);
       setError(message);
     },
   });

--- a/apps/web/src/admin-studio/FeeStructureEditor.tsx
+++ b/apps/web/src/admin-studio/FeeStructureEditor.tsx
@@ -210,7 +210,7 @@ export function FeeStructureEditor() {
     setSuccess(null);
     const body = {
       academic_year_id: form.academic_year_id,
-      term_id: form.term_id || null,
+      term_id: form.term_id || undefined,
       programme_id: form.programme_id,
       fee_type: form.fee_type,
       student_category: form.student_category,

--- a/apps/web/src/admin-studio/FeeStructureEditor.tsx
+++ b/apps/web/src/admin-studio/FeeStructureEditor.tsx
@@ -122,10 +122,18 @@ export function FeeStructureEditor() {
     },
     onError: (err) => {
       console.error("Fee structure creation error:", err);
+      if (err instanceof ApiError) {
+        console.log("ApiError body:", err.body);
+      }
       let message = "Failed to create fee structure";
       if (err instanceof ApiError && err.body && typeof err.body === "object" && "error" in err.body) {
         const errorData = (err.body as { error: unknown }).error;
-        message = typeof errorData === "string" ? errorData : JSON.stringify(errorData, null, 2);
+        // If error is just "error" string, that's not helpful - show status instead
+        if (errorData === "error") {
+          message = `Internal Server Error (${err.status}). Check API logs for details.`;
+        } else {
+          message = typeof errorData === "string" ? errorData : JSON.stringify(errorData, null, 2);
+        }
       } else if (err instanceof Error) {
         message = err.message;
       }
@@ -146,10 +154,18 @@ export function FeeStructureEditor() {
     },
     onError: (err) => {
       console.error("Fee structure update error:", err);
+      if (err instanceof ApiError) {
+        console.log("ApiError body:", err.body);
+      }
       let message = "Failed to update fee structure";
       if (err instanceof ApiError && err.body && typeof err.body === "object" && "error" in err.body) {
         const errorData = (err.body as { error: unknown }).error;
-        message = typeof errorData === "string" ? errorData : JSON.stringify(errorData, null, 2);
+        // If error is just "error" string, that's not helpful - show status instead
+        if (errorData === "error") {
+          message = `Internal Server Error (${err.status}). Check API logs for details.`;
+        } else {
+          message = typeof errorData === "string" ? errorData : JSON.stringify(errorData, null, 2);
+        }
       } else if (err instanceof Error) {
         message = err.message;
       }


### PR DESCRIPTION
## Summary
Fixes two critical UAT bugs identified during user acceptance testing:
- **#215**: Fee structure creation/editing shows generic error messages instead of actual validation errors
- **#204**: New mark submission returns API 422 error due to missing workflow configuration

## Changes

### Issue #215 - Fee Structure Error Visibility
**Problem**: Users saw "[object Object]" or generic "error" messages when fee structure operations failed.

**Root causes**:
1. Frontend error handler wasn't extracting the actual error message from `ApiError.body.error`
2. Zod validation errors are objects, not strings, causing "[object Object]" display
3. Unique constraint violations crashed the API with 500 errors
4. Optional fields (`description`, `term_id`) sent `null` instead of `undefined`, causing Zod validation failures

**Fixed**:
- ✅ Modified `FeeStructureEditor.tsx` error handlers to properly extract and display errors:
  - Checks if error is string or object
  - JSON.stringifies Zod validation objects for readable display
  - Special handling for generic "error" strings (shows "Internal Server Error")
- ✅ Added try-catch blocks in `fee-structures.routes.ts` to catch PostgreSQL unique constraint violations (error code 23505)
  - Returns 409 Conflict with user-friendly message instead of crashing
- ✅ Fixed optional field handling: sends `undefined` (omitted from JSON) instead of `null` for empty values

### Issue #204 - Marks Workflow Missing
**Problem**: Creating new mark submissions returned 422 error: "workflow marks not found in published config"

**Root cause**: Marks workflow definition was added to `seed.ts` but not backfilled to existing tenant configurations.

**Fixed**:
- ✅ Created migration `20260609000081_marks_workflow_config_backfill.sql`
- Backfills marks workflow definition to all published `platform.config_versions`
- Defines workflow states: DRAFT → SUBMITTED → HOD_REVIEW → APPROVED → PUBLISHED
- Defines transitions with role permissions (instructor, hod, registrar, admin)

## Testing
- [x] TypeScript compilation passes for both apps/web and apps/api
- [x] Deployed to staging and tested both fixes
- [x] Fee structure duplicate constraint shows clear error message
- [x] Fee structure validation errors display as formatted JSON
- [x] Fee structures can be created without selecting a term (valid use case)
- [x] Marks submission creates successfully with DRAFT workflow state

## Related Issues
Fixes #215
Fixes #204

## Migration
- Migration `20260609000081` needs to run on production to fix marks workflow issue
- No breaking changes
- Safe to deploy