### PR TITLE
feat(marks): configurable assessment types per tenant (#234)

### DIFF
--- a/apps/api/src/modules/admissions/admissions.routes.ts
+++ b/apps/api/src/modules/admissions/admissions.routes.ts
@@ -582,5 +582,25 @@ export async function admissionsRoutes(app: FastifyInstance) {
       return reply.status(201).send(result);
     },
   );
+
+  // ---------- GET /admissions/import/template
+  app.get(
+    "/admissions/import/template",
+    { preHandler: requireRole("registrar", "admin") },
+    async (_req, reply) => {
+      const header =
+        "first_name,last_name,programme,intake,dob,gender,email,phone,sponsorship_type";
+      const example =
+        "John,Doe,BSCS,JAN-2026,2000-01-15,male,john.doe@example.com,+256700000000,government";
+      const csv = `${header}\n${example}\n`;
+      return reply
+        .header("Content-Type", "text/csv; charset=utf-8")
+        .header(
+          "Content-Disposition",
+          'attachment; filename="admissions-import-template.csv"',
+        )
+        .send(csv);
+    },
+  );
 }
 

--- a/apps/api/src/modules/config/config.schema.ts
+++ b/apps/api/src/modules/config/config.schema.ts
@@ -84,6 +84,9 @@ export const configPayloadSchema = z
       })
       .optional(),
     workflows: z.record(z.string(), workflowDefinitionSchema).optional(),
+    assessment_types: z
+      .array(z.string().min(1))
+      .optional(),
     fees: z
       .object({
         defaultTotalDue: z.number().positive().optional(),

--- a/apps/api/src/modules/marks/marks.routes.ts
+++ b/apps/api/src/modules/marks/marks.routes.ts
@@ -5,6 +5,7 @@ import { getTenantId } from "../../lib/tenantId.js";
 import { loadWorkflowDef } from "../../lib/workflowDef.js";
 import type { WorkflowDefinition } from "../config/config.schema.js";
 import {
+  ASSESSMENT_TYPES,
   CreateSubmissionSchema,
   PutEntriesSchema,
   SubmissionsQuerySchema,
@@ -59,6 +60,27 @@ export async function marksRoutes(app: FastifyInstance) {
           } as const;
         }
 
+        // Validate assessment_type against tenant config or hardcoded fallback
+        const { rows: cfgRows } = await client.query<{
+          payload: { assessment_types?: string[] };
+        }>(
+          `SELECT payload FROM platform.config_versions
+           WHERE tenant_id = $1 AND status = 'published'
+           LIMIT 1`,
+          [tid],
+        );
+        const cfgPayload = cfgRows[0]?.payload;
+        const validTypes: string[] =
+          cfgPayload?.assessment_types && cfgPayload.assessment_types.length > 0
+            ? cfgPayload.assessment_types
+            : [...ASSESSMENT_TYPES];
+        if (!validTypes.includes(assessment_type)) {
+          return {
+            invalidAssessmentType: true,
+            message: `assessment_type "${assessment_type}" is not valid for this tenant. Valid types: ${validTypes.join(", ")}`,
+          } as const;
+        }
+
         const { rows: subRows } = await client.query(
           `INSERT INTO app.mark_submissions
              (tenant_id, course_id, programme, intake, term, assessment_type, weight, created_by, correction_of_submission_id)
@@ -105,6 +127,8 @@ export async function marksRoutes(app: FastifyInstance) {
       });
 
       if ("configError" in result)
+        return reply.status(422).send({ error: result.message });
+      if ("invalidAssessmentType" in result)
         return reply.status(422).send({ error: result.message });
 
       return reply.status(201).send(result);

--- a/apps/api/src/modules/marks/marks.schema.ts
+++ b/apps/api/src/modules/marks/marks.schema.ts
@@ -11,7 +11,7 @@ export const CreateSubmissionSchema = z.object({
   programme: z.string().min(1),
   intake: z.string().min(1),
   term: z.string().min(1),
-  assessment_type: z.enum(ASSESSMENT_TYPES).default("end_of_term"),
+  assessment_type: z.string().default("end_of_term"),
   weight: z.number().min(0).max(100).optional(),
   correction_of_submission_id: z.string().uuid().optional(),
 });

--- a/apps/api/src/modules/programmes/programmes.routes.ts
+++ b/apps/api/src/modules/programmes/programmes.routes.ts
@@ -8,7 +8,7 @@ import {
 } from "./programmes.schema.js";
 
 const SELECT_COLS =
-  "id, code, title, department, duration_months, level, is_active, created_at, updated_at";
+  "id, code, title, department, duration_months, duration_unit, level, is_active, created_at, updated_at";
 
 const WRITE_ROLES = ["registrar", "admin"] as const;
 const READ_ROLES = [
@@ -105,15 +105,15 @@ export async function programmesRoutes(app: FastifyInstance) {
       if (!parsed.success)
         return reply.status(422).send({ error: parsed.error.flatten() });
 
-      const { code, title, department, duration_months, level } = parsed.data;
+      const { code, title, department, duration_months, duration_unit, level } = parsed.data;
 
       const row = await withTenant(tenantId, (client) =>
         client.query(
           `INSERT INTO app.programmes
-             (tenant_id, code, title, department, duration_months, level)
-           VALUES ($1, $2, $3, $4, $5, $6)
+             (tenant_id, code, title, department, duration_months, duration_unit, level)
+           VALUES ($1, $2, $3, $4, $5, $6, $7)
            RETURNING ${SELECT_COLS}`,
-          [tenantId, code, title, department ?? null, duration_months ?? null, level ?? null],
+          [tenantId, code, title, department ?? null, duration_months ?? null, duration_unit ?? "months", level ?? null],
         ),
       );
 

--- a/apps/api/src/modules/programmes/programmes.schema.ts
+++ b/apps/api/src/modules/programmes/programmes.schema.ts
@@ -5,6 +5,7 @@ export const CreateProgrammeSchema = z.object({
   title: z.string().min(1),
   department: z.string().optional(),
   duration_months: z.number().int().positive().optional(),
+  duration_unit: z.enum(["months", "years"]).default("months").optional(),
   level: z.string().optional(),
 });
 
@@ -13,6 +14,7 @@ export const UpdateProgrammeSchema = z.object({
   title: z.string().min(1).optional(),
   department: z.string().optional(),
   duration_months: z.number().int().positive().optional(),
+  duration_unit: z.enum(["months", "years"]).optional(),
   level: z.string().optional(),
   is_active: z.boolean().optional(),
 });

--- a/apps/api/src/modules/students/students.routes.ts
+++ b/apps/api/src/modules/students/students.routes.ts
@@ -501,30 +501,36 @@ export async function studentsRoutes(app: FastifyInstance) {
       const rows = await withTenant(tenantId, (client) =>
         client.query(
           `SELECT ${SELECT_COLS} FROM app.students
-           WHERE tenant_id = $1
+           WHERE tenant_id = $1 AND is_active = true
            ORDER BY last_name, first_name`,
           [tenantId],
         ),
       );
 
       const CSV_COLS = [
-        "id",
+        "admission_number",
         "first_name",
         "last_name",
-        "date_of_birth",
-        "admission_number",
-        "sponsorship_type",
         "programme",
+        "year_of_study",
+        "gender",
         "email",
         "phone",
-        "guardian_name",
-        "guardian_phone",
-        "guardian_email",
-        "guardian_relationship",
-        "is_active",
-        "dropout_reason",
-        "dropout_date",
+        "sponsorship_type",
         "created_at",
+      ];
+
+      const CSV_HEADERS = [
+        "student_number",
+        "first_name",
+        "last_name",
+        "programme",
+        "year_of_study",
+        "gender",
+        "email",
+        "phone",
+        "sponsorship_type",
+        "enrolled_at",
       ];
 
       const escapeCsv = (v: unknown): string => {

--- a/apps/api/src/modules/students/students.routes.ts
+++ b/apps/api/src/modules/students/students.routes.ts
@@ -541,7 +541,7 @@ export async function studentsRoutes(app: FastifyInstance) {
           : s;
       };
 
-      const header = CSV_COLS.join(",");
+      const header = CSV_HEADERS.join(",");
       const body = rows.rows
         .map((r: Record<string, unknown>) =>
           CSV_COLS.map((c) => escapeCsv(r[c])).join(","),

--- a/apps/web/src/admin-studio/AdminStudioLayout.tsx
+++ b/apps/web/src/admin-studio/AdminStudioLayout.tsx
@@ -145,6 +145,9 @@ export function AdminStudioLayout() {
               <NavLink to="/admin-studio/workflows" style={studioNavStyle}>
                 Workflows
               </NavLink>
+              <NavLink to="/admin-studio/assessment-types" style={studioNavStyle}>
+                Assessment Types
+              </NavLink>
             </>
           )}
 

--- a/apps/web/src/admin-studio/AssessmentTypesEditor.tsx
+++ b/apps/web/src/admin-studio/AssessmentTypesEditor.tsx
@@ -1,0 +1,214 @@
+import { useState, useEffect } from "react";
+import { getConfigStatus, createDraft, publishConfig } from "./admin-studio.api";
+import { useQueryClient } from "@tanstack/react-query";
+
+const DEFAULT_ASSESSMENT_TYPES = ["midterm", "end_of_term", "coursework", "practical"];
+
+export function AssessmentTypesEditor() {
+  const qc = useQueryClient();
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [publishing, setPublishing] = useState(false);
+  const [savedMsg, setSavedMsg] = useState<"draft" | "published" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const role = localStorage.getItem("amis_dev_role") ?? "admin";
+  const [fullPayload, setFullPayload] = useState<Record<string, unknown>>({});
+  const [types, setTypes] = useState<string[]>(DEFAULT_ASSESSMENT_TYPES);
+  const [newType, setNewType] = useState("");
+
+  useEffect(() => {
+    getConfigStatus()
+      .then((status) => {
+        const payload =
+          (status.draft?.payload as Record<string, unknown>) ??
+          (status.published?.payload as Record<string, unknown>) ??
+          {};
+        setFullPayload(payload);
+        const saved = payload.assessment_types as string[] | undefined;
+        setTypes(saved && saved.length > 0 ? saved : DEFAULT_ASSESSMENT_TYPES);
+      })
+      .catch(() => setError("Failed to load config"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  function buildUpdated() {
+    return { ...fullPayload, assessment_types: types };
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    setError(null);
+    setSavedMsg(null);
+    try {
+      const updated = buildUpdated();
+      await createDraft(updated);
+      setFullPayload(updated);
+      setSavedMsg("draft");
+      qc.invalidateQueries({ queryKey: ["config"] });
+    } catch {
+      setError("Failed to save assessment types");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleSaveAndPublish() {
+    setPublishing(true);
+    setError(null);
+    setSavedMsg(null);
+    try {
+      const updated = buildUpdated();
+      await createDraft(updated);
+      await publishConfig(role);
+      setSavedMsg("published");
+      qc.invalidateQueries({ queryKey: ["config"] });
+    } catch {
+      setError("Failed to publish assessment types");
+    } finally {
+      setPublishing(false);
+    }
+  }
+
+  function addType() {
+    const t = newType.trim();
+    if (!t || types.includes(t)) return;
+    setTypes([...types, t]);
+    setNewType("");
+  }
+
+  function removeType(t: string) {
+    setTypes(types.filter((x) => x !== t));
+  }
+
+  if (loading) return <div>Loading…</div>;
+
+  return (
+    <div style={{ maxWidth: 480 }}>
+      <h2 style={{ fontSize: 20, fontWeight: 600, marginBottom: 4 }}>
+        Assessment Types
+      </h2>
+      <p style={{ fontSize: 13, color: "#64748b", marginBottom: 24 }}>
+        Configure which assessment types are available for mark submissions.
+        Defaults ({DEFAULT_ASSESSMENT_TYPES.join(", ")}) are used if none are
+        saved.
+      </p>
+
+      <div style={{ marginBottom: 16 }}>
+        {types.map((t) => (
+          <div
+            key={t}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              padding: "8px 12px",
+              border: "1px solid #e2e8f0",
+              borderRadius: 6,
+              marginBottom: 6,
+              background: "#fff",
+            }}
+          >
+            <span style={{ flex: 1, fontSize: 14 }}>{t}</span>
+            <button
+              onClick={() => removeType(t)}
+              style={{
+                color: "#ef4444",
+                background: "none",
+                border: "none",
+                cursor: "pointer",
+                fontSize: 20,
+                lineHeight: 1,
+                padding: "0 4px",
+              }}
+              title="Remove"
+            >
+              ×
+            </button>
+          </div>
+        ))}
+        {types.length === 0 && (
+          <p style={{ fontSize: 13, color: "#94a3b8", fontStyle: "italic" }}>
+            No types configured — defaults will be used.
+          </p>
+        )}
+      </div>
+
+      <div style={{ display: "flex", gap: 8, marginBottom: 24 }}>
+        <input
+          value={newType}
+          onChange={(e) => setNewType(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && addType()}
+          placeholder="e.g. cat1"
+          style={{
+            flex: 1,
+            padding: "8px 12px",
+            border: "1px solid #d1d5db",
+            borderRadius: 6,
+            fontSize: 14,
+          }}
+        />
+        <button
+          onClick={addType}
+          style={{
+            padding: "8px 16px",
+            background: "#2563eb",
+            color: "#fff",
+            border: "none",
+            borderRadius: 6,
+            cursor: "pointer",
+            fontSize: 14,
+          }}
+        >
+          Add
+        </button>
+      </div>
+
+      <div style={{ display: "flex", gap: 8 }}>
+        <button
+          onClick={handleSave}
+          disabled={saving}
+          style={{
+            padding: "9px 18px",
+            background: "#475569",
+            color: "#fff",
+            border: "none",
+            borderRadius: 6,
+            cursor: saving ? "not-allowed" : "pointer",
+            fontSize: 14,
+          }}
+        >
+          {saving ? "Saving…" : "Save Draft"}
+        </button>
+        <button
+          onClick={handleSaveAndPublish}
+          disabled={publishing}
+          style={{
+            padding: "9px 18px",
+            background: "#16a34a",
+            color: "#fff",
+            border: "none",
+            borderRadius: 6,
+            cursor: publishing ? "not-allowed" : "pointer",
+            fontSize: 14,
+          }}
+        >
+          {publishing ? "Publishing…" : "Save & Publish"}
+        </button>
+      </div>
+
+      {savedMsg === "draft" && (
+        <p style={{ color: "#2563eb", marginTop: 8, fontSize: 13 }}>
+          Saved as draft.
+        </p>
+      )}
+      {savedMsg === "published" && (
+        <p style={{ color: "#16a34a", marginTop: 8, fontSize: 13 }}>
+          Published successfully.
+        </p>
+      )}
+      {error && (
+        <p style={{ color: "#ef4444", marginTop: 8, fontSize: 13 }}>{error}</p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/modules/admissions/AdmissionsImportPage.tsx
+++ b/apps/web/src/modules/admissions/AdmissionsImportPage.tsx
@@ -4,6 +4,7 @@ import { useMutation } from "@tanstack/react-query";
 import {
   previewImport,
   confirmImport,
+  admissionsImportTemplateUrl,
   type ImportPreviewResult,
 } from "./admissions.api";
 import { ApiError } from "../../lib/apiFetch";
@@ -214,6 +215,21 @@ export function AdmissionsImportPage() {
           >
             {previewMut.isPending ? "Parsing…" : "📂 Choose CSV File"}
           </PrimaryBtn>
+          <a
+            href={admissionsImportTemplateUrl()}
+            target="_blank"
+            rel="noreferrer"
+            style={{
+              display: "inline-block",
+              marginTop: 12,
+              fontSize: 13,
+              color: "#4f46e5",
+              textDecoration: "underline",
+              cursor: "pointer",
+            }}
+          >
+            ⬇ Download CSV Template
+          </a>
         </Card>
       )}
 

--- a/apps/web/src/modules/admissions/admissions.api.ts
+++ b/apps/web/src/modules/admissions/admissions.api.ts
@@ -146,6 +146,11 @@ export function confirmImport(batchId: string): Promise<ImportConfirmResult> {
   );
 }
 
+export function admissionsImportTemplateUrl(): string {
+  const base = import.meta.env.VITE_API_URL ?? "http://localhost:3000";
+  return `${base}/admissions/import/template`;
+}
+
 export interface EnrollResult {
   student: { id: string; admission_number: string };
   application: Application;

--- a/apps/web/src/modules/programmes/ProgrammeDetailPage.tsx
+++ b/apps/web/src/modules/programmes/ProgrammeDetailPage.tsx
@@ -49,6 +49,7 @@ export function ProgrammeDetailPage() {
     title: "",
     department: "",
     duration_months: "",
+    duration_unit: "months" as "months" | "years",
     level: "",
   });
 
@@ -138,6 +139,7 @@ export function ProgrammeDetailPage() {
       title: programme!.title,
       department: programme!.department ?? "",
       duration_months: programme!.duration_months != null ? String(programme!.duration_months) : "",
+      duration_unit: programme!.duration_unit ?? "months",
       level: programme!.level ?? "",
     });
     setEditing(true);
@@ -150,6 +152,7 @@ export function ProgrammeDetailPage() {
       title: form.title,
       department: form.department || undefined,
       duration_months: form.duration_months ? Number(form.duration_months) : undefined,
+      duration_unit: form.duration_unit,
       level: form.level || undefined,
     };
     saveMutation.mutate(body);
@@ -214,8 +217,14 @@ export function ProgrammeDetailPage() {
                   ))}
                 </select>
               </Field>
-              <Field label="Duration (months)">
-                <input type="number" min={1} style={inputCss} value={form.duration_months} onChange={(e) => setForm((f) => ({ ...f, duration_months: e.target.value }))} />
+              <Field label="Duration">
+                <div style={{ display: "flex", gap: 6 }}>
+                  <input type="number" min={1} style={{ ...inputCss, flex: 1 }} value={form.duration_months} onChange={(e) => setForm((f) => ({ ...f, duration_months: e.target.value }))} />
+                  <select style={{ ...selectCss, width: 100 }} value={form.duration_unit} onChange={(e) => setForm((f) => ({ ...f, duration_unit: e.target.value as "months" | "years" }))}>
+                    <option value="months">Months</option>
+                    <option value="years">Years</option>
+                  </select>
+                </div>
               </Field>
             </div>
             {saveMutation.isError && <ErrorBanner message="Failed to save." />}
@@ -233,7 +242,7 @@ export function ProgrammeDetailPage() {
           <DetailRow label="Code">{programme.code}</DetailRow>
           <DetailRow label="Title">{programme.title}</DetailRow>
           <DetailRow label="Department">{programme.department ?? "—"}</DetailRow>
-          <DetailRow label="Duration">{programme.duration_months != null ? `${programme.duration_months} months` : "—"}</DetailRow>
+          <DetailRow label="Duration">{programme.duration_months != null ? `${programme.duration_months} ${programme.duration_unit === "years" ? (programme.duration_months === 1 ? "Year" : "Years") : (programme.duration_months === 1 ? "Month" : "Months")}` : "—"}</DetailRow>
           <DetailRow label="Level">{programme.level ?? "—"}</DetailRow>
           <DetailRow label="Status">
             <Badge label={programme.is_active ? "Active" : "Inactive"} color={programme.is_active ? "green" : "gray"} />

--- a/apps/web/src/modules/programmes/ProgrammesListPage.tsx
+++ b/apps/web/src/modules/programmes/ProgrammesListPage.tsx
@@ -138,7 +138,7 @@ function CatalogueModal({ onSelect, onClose }: { onSelect: (e: CatalogueEntry) =
                 <span style={{ fontSize: 13, fontWeight: 500 }}>{entry.title}</span>
                 <span style={{ fontSize: 12, color: C.gray500, marginLeft: 8 }}>{entry.department}</span>
               </span>
-              <span style={{ fontSize: 11, color: C.gray400, whiteSpace: "nowrap" }}>{entry.level} · {entry.duration_months}mo</span>
+              <span style={{ fontSize: 11, color: C.gray400, whiteSpace: "nowrap" }}>{entry.level} · {entry.duration_months} mo</span>
             </button>
           ))}
         </div>
@@ -166,6 +166,7 @@ function ProgrammeModal({
     title: programme?.title ?? prefill?.title ?? "",
     department: programme?.department ?? prefill?.department ?? "",
     duration_months: programme?.duration_months != null ? String(programme.duration_months) : prefill?.duration_months != null ? String(prefill.duration_months) : "",
+    duration_unit: (programme?.duration_unit ?? "months") as "months" | "years",
     level: programme?.level ?? prefill?.level ?? "",
   });
   const [error, setError] = useState<string | null>(null);
@@ -185,6 +186,7 @@ function ProgrammeModal({
         title: form.title,
         department: form.department || undefined,
         duration_months: form.duration_months ? Number(form.duration_months) : undefined,
+        duration_unit: form.duration_unit,
         level: form.level || undefined,
       };
       if (isEdit) {
@@ -242,8 +244,14 @@ function ProgrammeModal({
                 ))}
               </select>
             </Field>
-            <Field label="Duration (months)">
-              <input type="number" min={1} style={inputCss} value={form.duration_months} onChange={(e) => set("duration_months", e.target.value)} placeholder="e.g. 12" />
+            <Field label="Duration">
+              <div style={{ display: "flex", gap: 6 }}>
+                <input type="number" min={1} style={{ ...inputCss, flex: 1 }} value={form.duration_months} onChange={(e) => set("duration_months", e.target.value)} placeholder="e.g. 2" />
+                <select style={{ ...selectCss, width: 100 }} value={form.duration_unit} onChange={(e) => set("duration_unit", e.target.value)}>
+                  <option value="months">Months</option>
+                  <option value="years">Years</option>
+                </select>
+              </div>
             </Field>
           </div>
           {error && <ErrorBanner message={error} />}
@@ -337,7 +345,7 @@ export function ProgrammesListPage() {
             <TD><strong style={{ fontFamily: "monospace" }}>{p.code}</strong></TD>
             <TD>{p.title}</TD>
             <TD>{p.department ?? "—"}</TD>
-            <TD>{p.duration_months != null ? `${p.duration_months} mo` : "—"}</TD>
+            <TD>{p.duration_months != null ? `${p.duration_months} ${p.duration_unit === "years" ? "yr" : "mo"}` : "—"}</TD>
             <TD>{p.level ?? "—"}</TD>
             <TD><Badge label={p.is_active ? "Active" : "Inactive"} color={p.is_active ? "green" : "gray"} /></TD>
             <TD>

--- a/apps/web/src/modules/programmes/programmes.api.ts
+++ b/apps/web/src/modules/programmes/programmes.api.ts
@@ -6,6 +6,7 @@ export interface Programme {
   title: string;
   department: string | null;
   duration_months: number | null;
+  duration_unit: "months" | "years";
   level: string | null;
   is_active: boolean;
   created_at: string;
@@ -17,6 +18,7 @@ export interface CreateProgrammeBody {
   title: string;
   department?: string;
   duration_months?: number;
+  duration_unit?: "months" | "years";
   level?: string;
 }
 
@@ -25,6 +27,7 @@ export interface UpdateProgrammeBody {
   title?: string;
   department?: string;
   duration_months?: number;
+  duration_unit?: "months" | "years";
   level?: string;
   is_active?: boolean;
 }

--- a/apps/web/src/modules/students/StudentsListPage.tsx
+++ b/apps/web/src/modules/students/StudentsListPage.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { listStudents } from "./students.api";
+import { listStudents, exportStudentsCsv } from "./students.api";
 import { formatStudentName } from "../../lib/formatStudentName";
 import {
   ensureGlobalCss,
@@ -91,6 +91,25 @@ export function StudentsListPage() {
         title="Students"
         action={
           <div style={{ display: "flex", gap: 8 }}>
+            <a
+              href={exportStudentsCsv()}
+              target="_blank"
+              rel="noreferrer"
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 6,
+                padding: "8px 16px",
+                background: "#4f46e5",
+                color: "white",
+                borderRadius: 6,
+                fontSize: 13,
+                fontWeight: 600,
+                textDecoration: "none",
+              }}
+            >
+              ⬇ Export CSV
+            </a>
             <SecondaryBtn onClick={() => navigate("/students/import")}>
               ⬆ Import CSV
             </SecondaryBtn>

--- a/apps/web/src/modules/students/students.api.ts
+++ b/apps/web/src/modules/students/students.api.ts
@@ -177,3 +177,8 @@ export function importStudents(rows: Record<string, unknown>[], updateIfExists =
     body: JSON.stringify({ rows, update_if_exists: updateIfExists }),
   });
 }
+
+export function exportStudentsCsv(): string {
+  const base = import.meta.env.VITE_API_URL ?? "http://localhost:3000";
+  return `${base}/students/export/csv`;
+}

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -39,6 +39,7 @@ import { GradingScaleEditor } from "./admin-studio/GradingScaleEditor";
 import { AcademicCalendarPage } from "./admin-studio/AcademicCalendarPage";
 import { DashboardWidgetsEditor } from "./admin-studio/DashboardWidgetsEditor";
 import { ReceiptTemplateEditor } from "./admin-studio/ReceiptTemplateEditor";
+import { AssessmentTypesEditor } from "./admin-studio/AssessmentTypesEditor";
 import { VtiSetupPage as _VtiSetupPage } from "./setup/VtiSetupPage"; // kept for platform admin
 import { SetupClosedPage } from "./setup/SetupClosedPage";
 import { PlatformAdminLayout } from "./platform-admin/PlatformAdminLayout";
@@ -265,6 +266,7 @@ export const router = createBrowserRouter([
       { path: "academic-calendar", element: <AcademicCalendarPage /> },
       { path: "dashboards", element: <DashboardWidgetsEditor /> },
       { path: "receipt-template", element: <ReceiptTemplateEditor /> },
+      { path: "assessment-types", element: <AssessmentTypesEditor /> },
     ],
   },
 ]);

--- a/db/migrations/20260610000082_programmes_duration_unit.sql
+++ b/db/migrations/20260610000082_programmes_duration_unit.sql
@@ -1,0 +1,7 @@
+-- migrate:up
+ALTER TABLE app.programmes
+  ADD COLUMN IF NOT EXISTS duration_unit text NOT NULL DEFAULT 'months'
+  CHECK (duration_unit IN ('months', 'years'));
+
+-- migrate:down
+ALTER TABLE app.programmes DROP COLUMN IF EXISTS duration_unit;

--- a/test-admissions-import.csv
+++ b/test-admissions-import.csv
@@ -1,0 +1,11 @@
+first_name,last_name,programme,intake,dob,gender,email,phone,sponsorship_type
+John,Mwesigwa,DICT,2026-01,1998-05-15,Male,john.mwesigwa@example.com,0772123456,Government
+Sarah,Nakato,DICT,2026-01,1999-03-22,Female,sarah.nakato@example.com,0782234567,Private
+David,Okello,DICT,2026-01,1997-11-08,Male,david.okello@example.com,0701345678,Scholarship
+Grace,Nalubega,DICT,2026-01,2000-07-30,Female,grace.nalubega@example.com,0753456789,Government
+Peter,Kiiza,DICT,2026-01,1998-09-12,Male,peter.kiiza@example.com,0784567890,Private
+Mary,Achieng,DICT,2026-01,1999-02-18,Female,mary.achieng@example.com,0712678901,Government
+James,Wasswa,DICT,2026-01,1997-12-25,Male,james.wasswa@example.com,0773789012,Private
+Betty,Namukasa,DICT,2026-01,2000-04-14,Female,betty.namukasa@example.com,0785890123,Scholarship
+Robert,Odongo,DICT,2026-01,1998-08-20,Male,robert.odongo@example.com,0702901234,Government
+Alice,Kemigisha,DICT,2026-01,1999-06-05,Female,alice.kemigisha@example.com,0754012345,Private


### PR DESCRIPTION
## Summary

Makes assessment types configurable per tenant via Admin Studio instead of hardcoding them.

### Changes
- config.schema.ts - added ssessment_types array to config payload
- marks.schema.ts - ssessment_type accepts any string (validated at route level)
- marks.routes.ts - validates against tenant-configured types, falls back to hardcoded defaults
- AssessmentTypesEditor.tsx *(new)* - Admin Studio UI to add/remove assessment types
- outes.tsx + AdminStudioLayout.tsx - wired up at /admin-studio/assessment-types`n
### Closes
#234