### PR TITLE
fix(marks): assessment types from tenant config with proper display labels (#251)

### DIFF
--- a/apps/web/src/app/ConfigProvider.tsx
+++ b/apps/web/src/app/ConfigProvider.tsx
@@ -46,6 +46,7 @@ interface ConfigPayload {
     showBalance?: boolean;
   };
   modules?: Record<string, boolean>;
+  assessment_types?: string[];
 }
 
 interface ConfigData {
@@ -76,6 +77,7 @@ interface ConfigContextValue {
     showBalance: boolean;
   };
   enabledModules: Record<string, boolean>;
+  assessmentTypes: string[];
 }
 
 const ConfigContext = createContext<ConfigContextValue>({
@@ -98,6 +100,7 @@ const ConfigContext = createContext<ConfigContextValue>({
     showBalance: true,
   },
   enabledModules: {},
+  assessmentTypes: [],
 });
 
 export function useConfig() {
@@ -126,6 +129,7 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
   const departments = config?.payload?.institution?.departments ?? [];
   const designations = config?.payload?.institution?.designations ?? [];
   const enabledModules: Record<string, boolean> = config?.payload?.modules ?? {};
+  const assessmentTypes: string[] = config?.payload?.assessment_types ?? [];
   const rawReceipt = config?.payload?.receipt;
   const receiptConfig = {
     template: (rawReceipt?.template ?? "classic") as "classic" | "modern" | "minimal",
@@ -155,6 +159,7 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
         designations,
         receiptConfig,
         enabledModules,
+        assessmentTypes,
       }}
     >
       {children}

--- a/apps/web/src/modules/marks/BulkMarkEntryPage.tsx
+++ b/apps/web/src/modules/marks/BulkMarkEntryPage.tsx
@@ -25,6 +25,15 @@ const DEFAULT_ASSESSMENT_TYPES = [
   { value: "practical", label: "Practical" },
 ] as const;
 
+/** Convert snake_case or raw strings to Title Case for display.
+ *  e.g. "end_of_term" → "End of Term", "assignmnt" → "Assignmnt" */
+function formatAssessmentType(value: string): string {
+  return value
+    .split(/[_\s]+/)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
 export function BulkMarkEntryPage() {
   ensureGlobalCss();
   const [params] = useSearchParams();
@@ -32,7 +41,7 @@ export function BulkMarkEntryPage() {
   const { assessmentTypes: configTypes } = useConfig();
 
   const assessmentTypes = configTypes.length > 0
-    ? configTypes.map((t) => ({ value: t, label: t }))
+    ? configTypes.map((t) => ({ value: t, label: formatAssessmentType(t) }))
     : DEFAULT_ASSESSMENT_TYPES;
 
   const [selectedSubmissionId, setSelectedSubmissionId] = useState(

--- a/apps/web/src/modules/marks/BulkMarkEntryPage.tsx
+++ b/apps/web/src/modules/marks/BulkMarkEntryPage.tsx
@@ -3,6 +3,7 @@ import { useSearchParams } from "react-router-dom";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { listSubmissions, putEntries, type Submission } from "./marks.api";
 import { listStudents, type Student } from "../students/students.api";
+import { useConfig } from "../../app/ConfigProvider";
 import {
   ensureGlobalCss,
   PageHeader,
@@ -17,7 +18,7 @@ import {
   C,
 } from "../../lib/ui";
 
-const ASSESSMENT_TYPES = [
+const DEFAULT_ASSESSMENT_TYPES = [
   { value: "end_of_term", label: "End of Term" },
   { value: "midterm", label: "Midterm" },
   { value: "coursework", label: "Coursework" },
@@ -28,6 +29,11 @@ export function BulkMarkEntryPage() {
   ensureGlobalCss();
   const [params] = useSearchParams();
   const preSubmissionId = params.get("submission_id");
+  const { assessmentTypes: configTypes } = useConfig();
+
+  const assessmentTypes = configTypes.length > 0
+    ? configTypes.map((t) => ({ value: t, label: t }))
+    : DEFAULT_ASSESSMENT_TYPES;
 
   const [selectedSubmissionId, setSelectedSubmissionId] = useState(
     preSubmissionId ?? "",
@@ -123,7 +129,7 @@ export function BulkMarkEntryPage() {
             style={{ ...inputCss, width: 180 }}
           >
             <option value="">All Types</option>
-            {ASSESSMENT_TYPES.map((t) => (
+            {assessmentTypes.map((t) => (
               <option key={t.value} value={t.value}>
                 {t.label}
               </option>

--- a/apps/web/src/modules/marks/MarkCreatePage.tsx
+++ b/apps/web/src/modules/marks/MarkCreatePage.tsx
@@ -25,13 +25,22 @@ const DEFAULT_ASSESSMENT_TYPES = [
   { value: "practical", label: "Practical" },
 ];
 
+/** Convert snake_case or raw strings to Title Case for display.
+ *  e.g. "end_of_term" → "End of Term", "assignmnt" → "Assignmnt" */
+function formatAssessmentType(value: string): string {
+  return value
+    .split(/[_\s]+/)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
 export function MarkCreatePage() {
   ensureGlobalCss();
   const navigate = useNavigate();
   const { assessmentTypes: configTypes } = useConfig();
 
   const assessmentTypes = configTypes.length > 0
-    ? configTypes.map((t) => ({ value: t, label: t }))
+    ? configTypes.map((t) => ({ value: t, label: formatAssessmentType(t) }))
     : DEFAULT_ASSESSMENT_TYPES;
 
   const programmesQ = useQuery({

--- a/apps/web/src/modules/marks/MarkCreatePage.tsx
+++ b/apps/web/src/modules/marks/MarkCreatePage.tsx
@@ -5,6 +5,7 @@ import { createSubmission } from "./marks.api";
 import { listProgrammes } from "../programmes/programmes.api";
 import { listCourses } from "../courses/courses.api";
 import { listAcademicYears, listTerms } from "../academic-calendar/academic-calendar.api";
+import { useConfig } from "../../app/ConfigProvider";
 import {
   ensureGlobalCss,
   PageHeader,
@@ -17,7 +18,7 @@ import {
 } from "../../lib/ui";
 
 const TERMS = ["Term 1", "Term 2", "Term 3"];
-const ASSESSMENT_TYPES = [
+const DEFAULT_ASSESSMENT_TYPES = [
   { value: "midterm", label: "Midterm" },
   { value: "end_of_term", label: "End of Term" },
   { value: "coursework", label: "Coursework" },
@@ -27,6 +28,11 @@ const ASSESSMENT_TYPES = [
 export function MarkCreatePage() {
   ensureGlobalCss();
   const navigate = useNavigate();
+  const { assessmentTypes: configTypes } = useConfig();
+
+  const assessmentTypes = configTypes.length > 0
+    ? configTypes.map((t) => ({ value: t, label: t }))
+    : DEFAULT_ASSESSMENT_TYPES;
 
   const programmesQ = useQuery({
     queryKey: ["programmes"],
@@ -191,7 +197,7 @@ export function MarkCreatePage() {
               value={form.assessment_type}
               onChange={(e) => set("assessment_type", e.target.value)}
             >
-              {ASSESSMENT_TYPES.map((t) => (
+              {assessmentTypes.map((t) => (
                 <option key={t.value} value={t.value}>
                   {t.label}
                 </option>


### PR DESCRIPTION
## Summary
Wires up the configurable assessment types (added in #251) to the Marks forms.

### Changes
- ConfigProvider: exposes ssessmentTypes from the published tenant config
- MarkCreatePage + BulkMarkEntryPage: read types from config instead of hardcoded list; fall back to defaults when no config published
- Labels are formatted as Title Case (e.g. `end_of_term` ? **End of Term**, `midterm` ? **Midterm**)

### How to test
1. Admin Studio ? Assessment Types ? add/remove types ? save
2. Marks ? New Submission ? Assessment Type dropdown reflects your config
3. Without any config published, default types (Midterm, End of Term, Coursework, Practical) still appear

Fixes #251 (UAT regression)