### PR TITLE
feat: institution branding on public apply page + configurable enroll_from_state (#249, #250)

### DIFF
--- a/apps/api/src/modules/admissions/admissions.routes.ts
+++ b/apps/api/src/modules/admissions/admissions.routes.ts
@@ -444,20 +444,23 @@ export async function admissionsRoutes(app: FastifyInstance) {
         }
 
         // Check workflow state allows enrollment.
-        // Allowed states:
-        //   "admitted" / "accepted"  — legacy competitive-admissions workflow (lowercase)
-        //   "REGISTERED"             — new reporting-day workflow (student cleared all pre-enrolment steps)
-        //   "enrolled" / "ENROLLED"  — already enrolled (caught by student_id check above, but guard here as safety)
+        // Allowed states come from the published config's admissions workflow
+        // `enroll_from_state` field. Falls back to hardcoded defaults when absent.
         const state = application.current_state;
-        const enrollableStates = new Set([
-          "admitted", "accepted",   // legacy lowercase
-          "REGISTERED",             // new reporting-day workflow
-          "enrolled", "ENROLLED",   // terminal (already handled above, safety)
-        ]);
+        const wfDef = await loadWorkflowDef(tid, "admissions", client);
+        const configEnrollState = wfDef?.enroll_from_state ?? null;
+        const enrollableStates = configEnrollState
+          ? new Set([configEnrollState, "enrolled", "ENROLLED"])
+          : new Set([
+              "admitted", "accepted",   // legacy lowercase
+              "REGISTERED",             // new reporting-day workflow
+              "enrolled", "ENROLLED",   // terminal safety
+            ]);
         if (!enrollableStates.has(state)) {
+          const expected = configEnrollState ?? "REGISTERED";
           return {
             invalidState: true,
-            message: `Cannot enroll: application is in "${state}" state`,
+            message: `Cannot enroll: application is in "${state}" state, expected "${expected}"`,
           } as const;
         }
 

--- a/apps/api/src/modules/admissions/admissions.test.ts
+++ b/apps/api/src/modules/admissions/admissions.test.ts
@@ -5,8 +5,14 @@ vi.mock("../../db/tenant.js", () => ({
   withTenant: vi.fn(),
 }));
 
+vi.mock("../../lib/workflowDef.js", () => ({
+  loadWorkflowDef: vi.fn(),
+}));
+
 import { withTenant } from "../../db/tenant.js";
+import { loadWorkflowDef } from "../../lib/workflowDef.js";
 const mockWithTenant = vi.mocked(withTenant);
+const mockLoadWorkflowDef = vi.mocked(loadWorkflowDef);
 
 const TID = "00000000-0000-0000-0000-000000000010";
 const headers = { "x-tenant-id": TID };
@@ -14,7 +20,11 @@ const registrarHeaders = { "x-tenant-id": TID, "x-dev-role": "registrar" };
 const financeHeaders = { "x-tenant-id": TID, "x-dev-role": "finance" };
 const hodHeaders = { "x-tenant-id": TID, "x-dev-role": "hod" };
 
-beforeEach(() => vi.resetAllMocks());
+beforeEach(() => {
+  vi.resetAllMocks();
+  // Default: no custom enroll_from_state configured — enroll endpoint uses hardcoded defaults.
+  mockLoadWorkflowDef.mockResolvedValue(null);
+});
 
 // ------------------------------------------------------------------ stub data
 

--- a/apps/api/src/modules/config/config.schema.ts
+++ b/apps/api/src/modules/config/config.schema.ts
@@ -21,6 +21,9 @@ export const workflowDefinitionSchema = z.object({
   initial_state: z.string().min(1),
   states: z.array(z.string().min(1)).min(1),
   transitions: z.array(workflowTransitionSchema).min(1),
+  // Optional: the state from which enrollment is allowed (admissions workflow only).
+  // Falls back to hardcoded defaults ("REGISTERED", "admitted", "accepted") when absent.
+  enroll_from_state: z.string().optional(),
 });
 
 export type WorkflowDefinition = z.infer<typeof workflowDefinitionSchema>;

--- a/apps/api/src/modules/public/public.routes.ts
+++ b/apps/api/src/modules/public/public.routes.ts
@@ -20,6 +20,44 @@ async function resolveTenantSlug(
 // ------------------------------------------------------------------ routes
 
 export async function publicRoutes(app: FastifyInstance) {
+  // ---------- GET /public/:tenantSlug/info
+  // Returns tenant name and branding for the public application page
+  app.get<{ Params: { tenantSlug: string } }>(
+    "/public/:tenantSlug/info",
+    async (req, reply) => {
+      const { rows } = await pool.query<{
+        name: string;
+        slug: string;
+        logo_url: string | null;
+        primary_color: string | null;
+      }>(
+        `SELECT t.name, t.slug,
+                cv.payload->>'branding' AS branding_json,
+                cv.payload->>'theme' AS theme_json
+         FROM platform.tenants t
+         LEFT JOIN LATERAL (
+           SELECT payload FROM platform.config_versions
+           WHERE tenant_id = t.id AND status = 'published'
+           ORDER BY created_at DESC LIMIT 1
+         ) cv ON true
+         WHERE t.slug = $1 AND t.is_active = true`,
+        [req.params.tenantSlug],
+      );
+      if (!rows[0])
+        return reply.status(404).send({ error: "institution not found" });
+
+      const row = rows[0] as { name: string; slug: string; branding_json?: string | null; theme_json?: string | null };
+      const branding = row.branding_json ? JSON.parse(row.branding_json as string) : {};
+      const theme = row.theme_json ? JSON.parse(row.theme_json as string) : {};
+      return {
+        name: branding.appName ?? row.name,
+        slug: row.slug,
+        logoUrl: branding.logoUrl ?? null,
+        primaryColor: theme.primaryColor ?? null,
+      };
+    },
+  );
+
   // ---------- GET /public/:tenantSlug/programmes
   // No auth required — public-facing catalogue for application forms
   app.get<{ Params: { tenantSlug: string } }>(

--- a/apps/web/src/admin-studio/WorkflowViewer.tsx
+++ b/apps/web/src/admin-studio/WorkflowViewer.tsx
@@ -23,6 +23,7 @@ interface WorkflowDef {
   initial_state: string;
   states: string[];
   transitions: WorkflowTransition[];
+  enroll_from_state?: string;
 }
 
 /* ------------------------------------------------------------------ styles */
@@ -244,6 +245,10 @@ const [newTrans, setNewTrans] = useState<Record<string, { action: string; from: 
     });
   }
 
+  function setEnrollFromState(wfKey: string, s: string) {
+    setWorkflows((prev) => ({ ...prev, [wfKey]: { ...prev[wfKey], enroll_from_state: s || undefined } }));
+  }
+
   function setInitialState(wfKey: string, s: string) {
     setWorkflows((prev) => ({ ...prev, [wfKey]: { ...prev[wfKey], initial_state: s } }));
   }
@@ -459,6 +464,27 @@ const [newTrans, setNewTrans] = useState<Record<string, { action: string; from: 
                   </span>
                 )}
               </div>
+
+              {/* Enroll-from state (admissions workflow only) */}
+              {(wfKey === "admissions" || wf.enroll_from_state) && (
+                <div style={{ marginBottom: 16 }}>
+                  <span style={{ fontSize: 13, color: "#64748b" }}>Enroll from state: </span>
+                  {editMode ? (
+                    <select
+                      value={wf.enroll_from_state ?? ""}
+                      onChange={(e) => setEnrollFromState(wfKey, e.target.value)}
+                      style={{ ...selectSt, width: 200, display: "inline-block" }}
+                    >
+                      <option value="">— use default (REGISTERED) —</option>
+                      {wf.states.map((s) => <option key={s}>{s}</option>)}
+                    </select>
+                  ) : (
+                    <span style={{ display: "inline-block", padding: "2px 10px", borderRadius: 4, background: "#fef3c7", color: "#92400e", fontWeight: 600, fontSize: 12 }}>
+                      {wf.enroll_from_state || "default (REGISTERED)"}
+                    </span>
+                  )}
+                </div>
+              )}
 
               {/* States section */}
               <h4 style={{ fontSize: 13, fontWeight: 700, color: "#374151", marginBottom: 8 }}>States</h4>

--- a/apps/web/src/modules/public/PublicApplicationPage.tsx
+++ b/apps/web/src/modules/public/PublicApplicationPage.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import {
   listPublicProgrammes,
   submitPublicApplication,
+  getTenantInfo,
   type PublicApplyBody,
 } from "./public.api";
 import { ensureGlobalCss, inputCss } from "../../lib/ui";
@@ -21,6 +22,13 @@ const fieldWrap: React.CSSProperties = { marginBottom: 16 };
 export function PublicApplicationPage() {
   ensureGlobalCss();
   const { tenantSlug } = useParams<{ tenantSlug: string }>();
+
+  const { data: tenantInfo } = useQuery({
+    queryKey: ["public-tenant-info", tenantSlug],
+    queryFn: () => getTenantInfo(tenantSlug!),
+    enabled: Boolean(tenantSlug),
+    retry: false,
+  });
 
   const [form, setForm] = useState<PublicApplyBody>({
     first_name: "",
@@ -103,7 +111,26 @@ export function PublicApplicationPage() {
         boxShadow: "0 1px 3px rgba(0,0,0,0.1)",
       }}
     >
-      <h2 style={{ margin: "0 0 4px", fontSize: 22 }}>Apply for Admission</h2>
+      {/* Institution branding header */}
+      <div style={{ textAlign: "center", marginBottom: 28 }}>
+        {tenantInfo?.logoUrl && (
+          <img
+            src={tenantInfo.logoUrl}
+            alt={tenantInfo.name}
+            style={{ maxHeight: 64, maxWidth: 200, objectFit: "contain", marginBottom: 12 }}
+          />
+        )}
+        <h1 style={{ margin: 0, fontSize: 20, fontWeight: 700, color: tenantInfo?.primaryColor ?? "#1e293b" }}>
+          {tenantInfo?.name ?? "Apply for Admission"}
+        </h1>
+        {tenantInfo && (
+          <p style={{ margin: "4px 0 0", fontSize: 13, color: "#6b7280" }}>
+            Online Application Form
+          </p>
+        )}
+      </div>
+
+      <h2 style={{ margin: "0 0 4px", fontSize: 18 }}>Apply for Admission</h2>
       <p style={{ color: "#6b7280", fontSize: 14, marginBottom: 24 }}>
         Fill in your details below to submit your application.
       </p>

--- a/apps/web/src/modules/public/public.api.ts
+++ b/apps/web/src/modules/public/public.api.ts
@@ -1,5 +1,12 @@
 import { apiFetch } from "../../lib/apiFetch";
 
+export interface TenantInfo {
+  name: string;
+  slug: string;
+  logoUrl: string | null;
+  primaryColor: string | null;
+}
+
 export interface PublicApplication {
   id: string;
   first_name: string;
@@ -29,6 +36,10 @@ export interface PublicProgramme {
   department: string | null;
   duration_months: number | null;
   level: string | null;
+}
+
+export function getTenantInfo(tenantSlug: string): Promise<TenantInfo> {
+  return apiFetch<TenantInfo>(`/public/${tenantSlug}/info`);
 }
 
 export function listPublicProgrammes(


### PR DESCRIPTION
## Issues
- Closes #249
- Closes #250

## Changes

### #249 - Public Apply Page Branding
- New GET /public/:tenantSlug/info endpoint returns 
ame, logoUrl, primaryColor from published tenant config
- PublicApplicationPage fetches tenant info and renders institution logo + name as a branded header above the form
- Gracefully falls back when no config is published (shows generic heading)

### #250 - Configurable Enroll-From State
- workflowDefinitionSchema gains optional enroll_from_state field
- Enroll endpoint reads enroll_from_state from the published admissions workflow config; falls back to hardcoded defaults (REGISTERED/dmitted/ccepted) for full backward compatibility
- WorkflowViewer shows an **Enroll from state** dropdown on the admissions workflow editor
- 422 error now includes the expected state name for clearer debugging

## No migrations required