### PR TITLE
feat: configurable fee types/categories + Certificate vs Diploma filter (#231, #223)

### DIFF
--- a/apps/api/src/modules/config/config.schema.ts
+++ b/apps/api/src/modules/config/config.schema.ts
@@ -90,6 +90,16 @@ export const configPayloadSchema = z
     assessment_types: z
       .array(z.string().min(1))
       .optional(),
+    // Configurable fee type labels per tenant (e.g. "Tuition", "Boarding Fees", "Guild Fee").
+    // Defaults to ["tuition", "examination", "functional", "other"] when absent.
+    fee_types: z
+      .array(z.string().min(1))
+      .optional(),
+    // Configurable student category labels per tenant (e.g. "Resident", "Day").
+    // Defaults to ["all", "boarding", "day"] when absent.
+    student_categories: z
+      .array(z.string().min(1))
+      .optional(),
     fees: z
       .object({
         defaultTotalDue: z.number().positive().optional(),

--- a/apps/web/src/admin-studio/AdminStudioLayout.tsx
+++ b/apps/web/src/admin-studio/AdminStudioLayout.tsx
@@ -158,6 +158,9 @@ export function AdminStudioLayout() {
           <NavLink to="/admin-studio/fee-structure" style={studioNavStyle}>
             Fee Structures
           </NavLink>
+          <NavLink to="/admin-studio/fee-types" style={studioNavStyle}>
+            Fee Types &amp; Categories
+          </NavLink>
           <NavLink to="/admin-studio/grading" style={studioNavStyle}>
             Grading Scales
           </NavLink>

--- a/apps/web/src/admin-studio/FeeStructureEditor.tsx
+++ b/apps/web/src/admin-studio/FeeStructureEditor.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiFetch, ApiError } from "../lib/apiFetch";
+import { useConfig } from "../app/ConfigProvider";
 
 /* ------------------------------------------------------------------ types */
 
@@ -24,15 +25,12 @@ interface FeeStructure {
   is_active: boolean;
 }
 
-type FeeType = "tuition" | "functional" | "examination" | "other";
-type StudentCategory = "all" | "boarding" | "day";
+type FeeType = string;
+type StudentCategory = string;
 
-const FEE_TYPES: FeeType[] = ["tuition", "functional", "examination", "other"];
-const STUDENT_CATEGORIES: { value: StudentCategory; label: string }[] = [
-  { value: "all", label: "All students" },
-  { value: "boarding", label: "Boarding" },
-  { value: "day", label: "Day Scholar" },
-];
+// Built-in defaults — used only when no config is loaded yet.
+const DEFAULT_FEE_TYPES = ["tuition", "examination", "functional", "other"];
+const DEFAULT_STUDENT_CATEGORIES = ["all", "boarding", "day"];
 
 /* ------------------------------------------------------------------ styles */
 
@@ -61,6 +59,7 @@ const badgeStyle = (active: boolean): React.CSSProperties => ({
 /* ---------------------------------------------------------------- component */
 
 export function FeeStructureEditor() {
+  const { feeTypes = DEFAULT_FEE_TYPES, studentCategories = DEFAULT_STUDENT_CATEGORIES } = useConfig();
   const qc = useQueryClient();
   const [selectedYear, setSelectedYear] = useState<string>("");
   const [showForm, setShowForm] = useState(false);
@@ -183,7 +182,7 @@ export function FeeStructureEditor() {
   /* ---- helpers ---- */
 
   function resetForm() {
-    setForm({ academic_year_id: "", term_id: "", programme_id: "", fee_type: "tuition", student_category: "all", description: "", amount: "", currency: "UGX", is_active: true });
+    setForm({ academic_year_id: "", term_id: "", programme_id: "", fee_type: feeTypes[0] ?? "tuition", student_category: studentCategories[0] ?? "all", description: "", amount: "", currency: "UGX", is_active: true });
   }
 
   function openEdit(item: FeeStructure) {
@@ -293,14 +292,14 @@ export function FeeStructureEditor() {
               </div>
               <div>
                 <label style={labelSt}>Fee Type *</label>
-                <select required value={form.fee_type} onChange={(e) => setForm((f) => ({ ...f, fee_type: e.target.value as FeeType }))} style={selectSt}>
-                  {FEE_TYPES.map((t) => <option key={t} value={t}>{t.charAt(0).toUpperCase() + t.slice(1)}</option>)}
+                <select required value={form.fee_type} onChange={(e) => setForm((f) => ({ ...f, fee_type: e.target.value }))} style={selectSt}>
+                  {feeTypes.map((t) => <option key={t} value={t}>{t.charAt(0).toUpperCase() + t.slice(1)}</option>)}
                 </select>
               </div>
               <div>
                 <label style={labelSt}>Student Category</label>
-                <select value={form.student_category} onChange={(e) => setForm((f) => ({ ...f, student_category: e.target.value as StudentCategory }))} style={selectSt}>
-                  {STUDENT_CATEGORIES.map((c) => <option key={c.value} value={c.value}>{c.label}</option>)}
+                <select value={form.student_category} onChange={(e) => setForm((f) => ({ ...f, student_category: e.target.value }))} style={selectSt}>
+                  {studentCategories.map((c) => <option key={c} value={c}>{c.charAt(0).toUpperCase() + c.slice(1)}</option>)}
                 </select>
               </div>
               <div>
@@ -376,9 +375,9 @@ export function FeeStructureEditor() {
                     <td style={td}><strong>{fs.programme_code}</strong> — {fs.programme_title}</td>
                     <td style={td}>{fs.fee_type.charAt(0).toUpperCase() + fs.fee_type.slice(1)}</td>
                     <td style={td}>
-                      {fs.student_category === "boarding" && <span style={{ padding: "2px 8px", borderRadius: 20, fontSize: 11, fontWeight: 700, background: "#dbeafe", color: "#1d4ed8" }}>Boarding</span>}
-                      {fs.student_category === "day" && <span style={{ padding: "2px 8px", borderRadius: 20, fontSize: 11, fontWeight: 700, background: "#fef9c3", color: "#854d0e" }}>Day Scholar</span>}
-                      {(!fs.student_category || fs.student_category === "all") && <span style={{ color: "#94a3b8", fontSize: 12 }}>All</span>}
+                      <span style={{ padding: "2px 8px", borderRadius: 20, fontSize: 11, fontWeight: 700, background: "#f1f5f9", color: "#475569" }}>
+                        {fs.student_category ? fs.student_category.charAt(0).toUpperCase() + fs.student_category.slice(1) : "All"}
+                      </span>
                     </td>
                     <td style={{ ...td, color: "#64748b" }}>{terms.find((t) => t.id === fs.term_id)?.name ?? "Year-level"}</td>
                     <td style={{ ...td, fontWeight: 700 }}>{fs.currency} {parseFloat(fs.amount).toLocaleString()}</td>

--- a/apps/web/src/admin-studio/FeeTypesEditor.tsx
+++ b/apps/web/src/admin-studio/FeeTypesEditor.tsx
@@ -1,0 +1,203 @@
+import { useState, useEffect } from "react";
+import { getConfigStatus, createDraft, publishConfig } from "./admin-studio.api";
+import { useQueryClient } from "@tanstack/react-query";
+
+const DEFAULT_FEE_TYPES = ["tuition", "examination", "functional", "other"];
+const DEFAULT_STUDENT_CATEGORIES = ["all", "boarding", "day"];
+
+const inputSt: React.CSSProperties = {
+  padding: "7px 10px", border: "1px solid #d1d5db",
+  borderRadius: 6, fontSize: 13, width: "100%", boxSizing: "border-box",
+};
+
+export function FeeTypesEditor() {
+  const qc = useQueryClient();
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [publishing, setPublishing] = useState(false);
+  const [savedMsg, setSavedMsg] = useState<"draft" | "published" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const role = localStorage.getItem("amis_dev_role") ?? "admin";
+  const [fullPayload, setFullPayload] = useState<Record<string, unknown>>({});
+  const [feeTypes, setFeeTypes] = useState<string[]>(DEFAULT_FEE_TYPES);
+  const [studentCategories, setStudentCategories] = useState<string[]>(DEFAULT_STUDENT_CATEGORIES);
+  const [newFeeType, setNewFeeType] = useState("");
+  const [newCategory, setNewCategory] = useState("");
+
+  useEffect(() => {
+    getConfigStatus()
+      .then((status) => {
+        const payload =
+          (status.draft?.payload as Record<string, unknown>) ??
+          (status.published?.payload as Record<string, unknown>) ??
+          {};
+        setFullPayload(payload);
+        const savedFeeTypes = payload.fee_types as string[] | undefined;
+        const savedCategories = payload.student_categories as string[] | undefined;
+        setFeeTypes(savedFeeTypes && savedFeeTypes.length > 0 ? savedFeeTypes : DEFAULT_FEE_TYPES);
+        setStudentCategories(savedCategories && savedCategories.length > 0 ? savedCategories : DEFAULT_STUDENT_CATEGORIES);
+      })
+      .catch(() => setError("Failed to load config"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  function buildUpdated() {
+    return { ...fullPayload, fee_types: feeTypes, student_categories: studentCategories };
+  }
+
+  async function handleSave() {
+    setSaving(true); setError(null); setSavedMsg(null);
+    try {
+      const updated = buildUpdated();
+      await createDraft(updated);
+      setFullPayload(updated);
+      setSavedMsg("draft");
+      qc.invalidateQueries({ queryKey: ["config"] });
+    } catch {
+      setError("Failed to save fee configuration");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleSaveAndPublish() {
+    setPublishing(true); setError(null); setSavedMsg(null);
+    try {
+      const updated = buildUpdated();
+      await createDraft(updated);
+      await publishConfig(role);
+      setSavedMsg("published");
+      qc.invalidateQueries({ queryKey: ["config"] });
+    } catch {
+      setError("Failed to publish fee configuration");
+    } finally {
+      setPublishing(false);
+    }
+  }
+
+  function addFeeType() {
+    const t = newFeeType.trim();
+    if (!t || feeTypes.includes(t)) return;
+    setFeeTypes([...feeTypes, t]);
+    setNewFeeType("");
+  }
+
+  function addCategory() {
+    const c = newCategory.trim();
+    if (!c || studentCategories.includes(c)) return;
+    setStudentCategories([...studentCategories, c]);
+    setNewCategory("");
+  }
+
+  const chipSt: React.CSSProperties = {
+    display: "flex", alignItems: "center", gap: 8,
+    padding: "8px 12px", border: "1px solid #e2e8f0", borderRadius: 6,
+    marginBottom: 6, background: "#fff",
+  };
+  const removeBtnSt: React.CSSProperties = {
+    color: "#ef4444", background: "none", border: "none",
+    cursor: "pointer", fontSize: 20, lineHeight: "1", padding: "0 2px",
+  };
+
+  if (loading) return <div>Loading…</div>;
+
+  return (
+    <div style={{ maxWidth: 540 }}>
+      <h2 style={{ fontSize: 20, fontWeight: 600, marginBottom: 4 }}>Fee Types &amp; Student Categories</h2>
+      <p style={{ fontSize: 13, color: "#64748b", marginBottom: 28 }}>
+        Configure the fee type labels and student category labels available when building fee structures.
+        Defaults are used when none are saved.
+      </p>
+
+      {/* Fee Types section */}
+      <div style={{ marginBottom: 32 }}>
+        <h3 style={{ fontSize: 15, fontWeight: 700, color: "#0f172a", marginBottom: 12 }}>Fee Types</h3>
+        <p style={{ fontSize: 12, color: "#94a3b8", marginBottom: 12 }}>
+          Defaults: {DEFAULT_FEE_TYPES.join(", ")}
+        </p>
+        <div style={{ marginBottom: 12 }}>
+          {feeTypes.map((t) => (
+            <div key={t} style={chipSt}>
+              <span style={{ flex: 1, fontSize: 14 }}>{t}</span>
+              <button onClick={() => setFeeTypes(feeTypes.filter((x) => x !== t))} style={removeBtnSt} title="Remove">×</button>
+            </div>
+          ))}
+        </div>
+        <div style={{ display: "flex", gap: 8 }}>
+          <input
+            value={newFeeType}
+            onChange={(e) => setNewFeeType(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && (e.preventDefault(), addFeeType())}
+            placeholder="e.g. Boarding Fees"
+            style={{ ...inputSt, width: "auto", flex: 1 }}
+          />
+          <button
+            onClick={addFeeType}
+            style={{ padding: "7px 16px", background: "#2563eb", color: "#fff", border: "none", borderRadius: 6, fontWeight: 600, fontSize: 13, cursor: "pointer" }}
+          >
+            Add
+          </button>
+        </div>
+      </div>
+
+      {/* Student Categories section */}
+      <div style={{ marginBottom: 32 }}>
+        <h3 style={{ fontSize: 15, fontWeight: 700, color: "#0f172a", marginBottom: 12 }}>Student Categories</h3>
+        <p style={{ fontSize: 12, color: "#94a3b8", marginBottom: 12 }}>
+          Defaults: {DEFAULT_STUDENT_CATEGORIES.join(", ")}
+        </p>
+        <div style={{ marginBottom: 12 }}>
+          {studentCategories.map((c) => (
+            <div key={c} style={chipSt}>
+              <span style={{ flex: 1, fontSize: 14 }}>{c}</span>
+              <button onClick={() => setStudentCategories(studentCategories.filter((x) => x !== c))} style={removeBtnSt} title="Remove">×</button>
+            </div>
+          ))}
+        </div>
+        <div style={{ display: "flex", gap: 8 }}>
+          <input
+            value={newCategory}
+            onChange={(e) => setNewCategory(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && (e.preventDefault(), addCategory())}
+            placeholder="e.g. Resident"
+            style={{ ...inputSt, width: "auto", flex: 1 }}
+          />
+          <button
+            onClick={addCategory}
+            style={{ padding: "7px 16px", background: "#2563eb", color: "#fff", border: "none", borderRadius: 6, fontWeight: 600, fontSize: 13, cursor: "pointer" }}
+          >
+            Add
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div style={{ padding: "8px 14px", background: "#fee2e2", color: "#dc2626", borderRadius: 6, fontSize: 13, marginBottom: 12 }}>
+          {error}
+        </div>
+      )}
+      {savedMsg && (
+        <div style={{ padding: "8px 14px", background: "#dcfce7", color: "#15803d", borderRadius: 6, fontSize: 13, fontWeight: 600, marginBottom: 12 }}>
+          ✓ {savedMsg === "published" ? "Published!" : "Saved as draft."}
+        </div>
+      )}
+
+      <div style={{ display: "flex", gap: 10 }}>
+        <button
+          onClick={handleSave}
+          disabled={saving || publishing}
+          style={{ padding: "9px 20px", background: saving ? "#93c5fd" : "#2563eb", color: "#fff", border: "none", borderRadius: 7, fontWeight: 700, fontSize: 13, cursor: saving ? "not-allowed" : "pointer" }}
+        >
+          {saving ? "Saving…" : "Save Draft"}
+        </button>
+        <button
+          onClick={handleSaveAndPublish}
+          disabled={saving || publishing}
+          style={{ padding: "9px 20px", background: publishing ? "#86efac" : "#16a34a", color: "#fff", border: "none", borderRadius: 7, fontWeight: 700, fontSize: 13, cursor: publishing ? "not-allowed" : "pointer" }}
+        >
+          {publishing ? "Publishing…" : "Save & Publish"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/ConfigProvider.tsx
+++ b/apps/web/src/app/ConfigProvider.tsx
@@ -47,6 +47,8 @@ interface ConfigPayload {
   };
   modules?: Record<string, boolean>;
   assessment_types?: string[];
+  fee_types?: string[];
+  student_categories?: string[];
 }
 
 interface ConfigData {
@@ -78,6 +80,8 @@ interface ConfigContextValue {
   };
   enabledModules: Record<string, boolean>;
   assessmentTypes: string[];
+  feeTypes: string[];
+  studentCategories: string[];
 }
 
 const ConfigContext = createContext<ConfigContextValue>({
@@ -101,6 +105,8 @@ const ConfigContext = createContext<ConfigContextValue>({
   },
   enabledModules: {},
   assessmentTypes: [],
+  feeTypes: ["tuition", "examination", "functional", "other"],
+  studentCategories: ["all", "boarding", "day"],
 });
 
 export function useConfig() {
@@ -130,6 +136,8 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
   const designations = config?.payload?.institution?.designations ?? [];
   const enabledModules: Record<string, boolean> = config?.payload?.modules ?? {};
   const assessmentTypes: string[] = config?.payload?.assessment_types ?? [];
+  const feeTypes: string[] = config?.payload?.fee_types ?? ["tuition", "examination", "functional", "other"];
+  const studentCategories: string[] = config?.payload?.student_categories ?? ["all", "boarding", "day"];
   const rawReceipt = config?.payload?.receipt;
   const receiptConfig = {
     template: (rawReceipt?.template ?? "classic") as "classic" | "modern" | "minimal",
@@ -160,6 +168,8 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
         receiptConfig,
         enabledModules,
         assessmentTypes,
+        feeTypes,
+        studentCategories,
       }}
     >
       {children}

--- a/apps/web/src/modules/admissions/ApplicationCreatePage.tsx
+++ b/apps/web/src/modules/admissions/ApplicationCreatePage.tsx
@@ -16,6 +16,8 @@ import {
 } from "../../lib/ui";
 
 const SPONSORSHIP_TYPES = ["Government", "Private", "Self-Sponsored", "Scholarship", "Other"];
+const PROGRAMME_TYPES = ["Certificate", "Diploma"] as const;
+type ProgrammeType = typeof PROGRAMME_TYPES[number];
 
 export function ApplicationCreatePage() {
   ensureGlobalCss();
@@ -48,12 +50,21 @@ export function ApplicationCreatePage() {
     intake: "",
     sponsorship_type: "",
   });
+  const [programmeType, setProgrammeType] = useState<ProgrammeType | "">("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   function set(field: string, value: string) {
     setForm((f) => ({ ...f, [field]: value }));
   }
+
+  // Filter programmes by selected type; fall back to all if none selected or
+  // if a programme has no level set (treat as compatible with both types).
+  const visibleProgrammes = (programmes ?? []).filter((p) => {
+    if (!programmeType) return true;
+    if (!p.level) return true; // no level set — show in all
+    return p.level.toLowerCase().includes(programmeType.toLowerCase());
+  });
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -160,6 +171,21 @@ export function ApplicationCreatePage() {
           </div>
 
           <div style={twoColGrid}>
+            <Field label="Programme Type">
+              <select
+                style={selectCss}
+                value={programmeType}
+                onChange={(e) => {
+                  setProgrammeType(e.target.value as ProgrammeType | "");
+                  set("programme", ""); // reset programme when type changes
+                }}
+              >
+                <option value="">— All Types —</option>
+                {PROGRAMME_TYPES.map((t) => (
+                  <option key={t} value={t}>{t}</option>
+                ))}
+              </select>
+            </Field>
             <Field label="Programme" required>
               <select
                 required
@@ -168,14 +194,16 @@ export function ApplicationCreatePage() {
                 onChange={(e) => set("programme", e.target.value)}
               >
                 <option value="">— Select Programme —</option>
-                {(programmes ?? []).map((p) => (
+                {visibleProgrammes.map((p) => (
                   <option key={p.id} value={p.code}>
                     {p.code} — {p.title}
                   </option>
                 ))}
               </select>
             </Field>
-            <Field label="Intake" required>
+          </div>
+
+          <Field label="Intake" required>
               <select
                 required
                 style={selectCss}
@@ -190,7 +218,6 @@ export function ApplicationCreatePage() {
                 ))}
               </select>
             </Field>
-          </div>
 
           <Field label="Sponsorship Type">
             <select

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -40,6 +40,7 @@ import { AcademicCalendarPage } from "./admin-studio/AcademicCalendarPage";
 import { DashboardWidgetsEditor } from "./admin-studio/DashboardWidgetsEditor";
 import { ReceiptTemplateEditor } from "./admin-studio/ReceiptTemplateEditor";
 import { AssessmentTypesEditor } from "./admin-studio/AssessmentTypesEditor";
+import { FeeTypesEditor } from "./admin-studio/FeeTypesEditor";
 import { VtiSetupPage as _VtiSetupPage } from "./setup/VtiSetupPage"; // kept for platform admin
 import { SetupClosedPage } from "./setup/SetupClosedPage";
 import { PlatformAdminLayout } from "./platform-admin/PlatformAdminLayout";
@@ -267,6 +268,7 @@ export const router = createBrowserRouter([
       { path: "dashboards", element: <DashboardWidgetsEditor /> },
       { path: "receipt-template", element: <ReceiptTemplateEditor /> },
       { path: "assessment-types", element: <AssessmentTypesEditor /> },
+      { path: "fee-types", element: <FeeTypesEditor /> },
     ],
   },
 ]);


### PR DESCRIPTION
## Issues
- Closes #231
- Closes #223

### #231 - Fully configurable fee types per tenant
- `configPayloadSchema` gains `fee_types` and `student_categories` string arrays
- `ConfigProvider` exposes `feeTypes` and `studentCategories` with sensible defaults
- `FeeStructureEditor` uses config values instead of hardcoded arrays
- New **Fee Types & Categories** editor in Admin Studio lets admins add/remove fee type labels and student category labels (e.g. Boarding Fees, Guild Fee, Resident, Day)

### #223 - Certificate vs Diploma distinction in admissions
- `ApplicationCreatePage` gains a **Programme Type** selector (Certificate | Diploma | All)
- Selecting a type filters the Programme dropdown to matching programmes (by `level` field)
- Programmes without a `level` set appear in all type views for backward compatibility

No DB migrations required.