### PR TITLE
feat(#227,#219): custom departments editor + full application fields

### DIFF
--- a/apps/web/src/admin-studio/AdminStudioLayout.tsx
+++ b/apps/web/src/admin-studio/AdminStudioLayout.tsx
@@ -161,6 +161,9 @@ export function AdminStudioLayout() {
           <NavLink to="/admin-studio/fee-types" style={studioNavStyle}>
             Fee Types &amp; Categories
           </NavLink>
+          <NavLink to="/admin-studio/departments" style={studioNavStyle}>
+            Departments
+          </NavLink>
           <NavLink to="/admin-studio/grading" style={studioNavStyle}>
             Grading Scales
           </NavLink>

--- a/apps/web/src/admin-studio/DepartmentsEditor.tsx
+++ b/apps/web/src/admin-studio/DepartmentsEditor.tsx
@@ -1,0 +1,161 @@
+import { useState, useEffect } from "react";
+import { getConfigStatus, createDraft, publishConfig } from "./admin-studio.api";
+import { useQueryClient } from "@tanstack/react-query";
+
+const DEFAULT_DEPARTMENTS = [
+  "ICT", "Business", "Engineering", "Construction", "Electrical",
+  "Automotive", "Hospitality", "Agriculture", "Health Sciences", "Others",
+];
+
+const inputSt: React.CSSProperties = {
+  padding: "7px 10px", border: "1px solid #d1d5db",
+  borderRadius: 6, fontSize: 13, width: "100%", boxSizing: "border-box",
+};
+
+export function DepartmentsEditor() {
+  const qc = useQueryClient();
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [publishing, setPublishing] = useState(false);
+  const [savedMsg, setSavedMsg] = useState<"draft" | "published" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const role = localStorage.getItem("amis_dev_role") ?? "admin";
+  const [fullPayload, setFullPayload] = useState<Record<string, unknown>>({});
+  const [departments, setDepartments] = useState<string[]>(DEFAULT_DEPARTMENTS);
+  const [newDept, setNewDept] = useState("");
+
+  useEffect(() => {
+    getConfigStatus()
+      .then((status) => {
+        const payload =
+          (status.draft?.payload as Record<string, unknown>) ??
+          (status.published?.payload as Record<string, unknown>) ??
+          {};
+        setFullPayload(payload);
+        const institution = payload.institution as { departments?: string[] } | undefined;
+        const saved = institution?.departments;
+        setDepartments(saved && saved.length > 0 ? saved : DEFAULT_DEPARTMENTS);
+      })
+      .catch(() => setError("Failed to load config"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  function buildUpdated() {
+    const existing = (fullPayload.institution as Record<string, unknown>) ?? {};
+    return { ...fullPayload, institution: { ...existing, departments } };
+  }
+
+  async function handleSave() {
+    setSaving(true); setError(null); setSavedMsg(null);
+    try {
+      const updated = buildUpdated();
+      await createDraft(updated);
+      setFullPayload(updated);
+      setSavedMsg("draft");
+      qc.invalidateQueries({ queryKey: ["config"] });
+    } catch {
+      setError("Failed to save departments");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleSaveAndPublish() {
+    setPublishing(true); setError(null); setSavedMsg(null);
+    try {
+      const updated = buildUpdated();
+      await createDraft(updated);
+      await publishConfig(role);
+      setSavedMsg("published");
+      qc.invalidateQueries({ queryKey: ["config"] });
+    } catch {
+      setError("Failed to publish departments");
+    } finally {
+      setPublishing(false);
+    }
+  }
+
+  function addDept() {
+    const d = newDept.trim();
+    if (!d || departments.includes(d)) return;
+    setDepartments([...departments, d]);
+    setNewDept("");
+  }
+
+  const chipSt: React.CSSProperties = {
+    display: "flex", alignItems: "center", gap: 8,
+    padding: "8px 12px", border: "1px solid #e2e8f0", borderRadius: 6,
+    marginBottom: 6, background: "#fff",
+  };
+
+  if (loading) return <div>Loading…</div>;
+
+  return (
+    <div style={{ maxWidth: 480 }}>
+      <h2 style={{ fontSize: 20, fontWeight: 600, marginBottom: 4 }}>Departments</h2>
+      <p style={{ fontSize: 13, color: "#64748b", marginBottom: 24 }}>
+        Configure the departments available when creating or editing programmes.
+        Defaults ({DEFAULT_DEPARTMENTS.slice(0, 4).join(", ")}, …) are used when none are saved.
+      </p>
+
+      <div style={{ marginBottom: 16 }}>
+        {departments.map((d) => (
+          <div key={d} style={chipSt}>
+            <span style={{ flex: 1, fontSize: 14 }}>{d}</span>
+            <button
+              onClick={() => setDepartments(departments.filter((x) => x !== d))}
+              style={{ color: "#ef4444", background: "none", border: "none", cursor: "pointer", fontSize: 20, lineHeight: "1", padding: "0 2px" }}
+              title="Remove"
+            >
+              ×
+            </button>
+          </div>
+        ))}
+      </div>
+
+      <div style={{ display: "flex", gap: 8, marginBottom: 24 }}>
+        <input
+          value={newDept}
+          onChange={(e) => setNewDept(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && (e.preventDefault(), addDept())}
+          placeholder="e.g. Civil Engineering"
+          style={{ ...inputSt, flex: 1 }}
+        />
+        <button
+          onClick={addDept}
+          style={{ padding: "7px 16px", background: "#2563eb", color: "#fff", border: "none", borderRadius: 6, fontWeight: 600, fontSize: 13, cursor: "pointer" }}
+        >
+          Add
+        </button>
+      </div>
+
+      {error && (
+        <div style={{ padding: "8px 14px", background: "#fee2e2", color: "#dc2626", borderRadius: 6, fontSize: 13, marginBottom: 12 }}>
+          {error}
+        </div>
+      )}
+      {savedMsg && (
+        <div style={{ padding: "8px 14px", background: "#dcfce7", color: "#15803d", borderRadius: 6, fontSize: 13, fontWeight: 600, marginBottom: 12 }}>
+          ✓ {savedMsg === "published" ? "Published!" : "Saved as draft."}
+        </div>
+      )}
+
+      <div style={{ display: "flex", gap: 10 }}>
+        <button
+          onClick={handleSave}
+          disabled={saving || publishing}
+          style={{ padding: "9px 20px", background: saving ? "#93c5fd" : "#2563eb", color: "#fff", border: "none", borderRadius: 7, fontWeight: 700, fontSize: 13, cursor: saving ? "not-allowed" : "pointer" }}
+        >
+          {saving ? "Saving…" : "Save Draft"}
+        </button>
+        <button
+          onClick={handleSaveAndPublish}
+          disabled={saving || publishing}
+          style={{ padding: "9px 20px", background: publishing ? "#86efac" : "#16a34a", color: "#fff", border: "none", borderRadius: 7, fontWeight: 700, fontSize: 13, cursor: publishing ? "not-allowed" : "pointer" }}
+        >
+          {publishing ? "Publishing…" : "Save & Publish"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/modules/admissions/ApplicationCreatePage.tsx
+++ b/apps/web/src/modules/admissions/ApplicationCreatePage.tsx
@@ -17,7 +17,15 @@ import {
 
 const SPONSORSHIP_TYPES = ["Government", "Private", "Self-Sponsored", "Scholarship", "Other"];
 const PROGRAMME_TYPES = ["Certificate", "Diploma"] as const;
+const MARITAL_STATUSES = ["Single", "Married", "Widowed", "Divorced"];
+const RESIDENCY_TYPES = ["Resident", "Non-Resident"];
 type ProgrammeType = typeof PROGRAMME_TYPES[number];
+
+const sectionHeading: React.CSSProperties = {
+  fontSize: 13, fontWeight: 700, color: "#374151", textTransform: "uppercase",
+  letterSpacing: "0.05em", padding: "8px 0 4px",
+  borderBottom: "1px solid #e2e8f0", marginBottom: 8,
+};
 
 export function ApplicationCreatePage() {
   ensureGlobalCss();
@@ -40,15 +48,16 @@ export function ApplicationCreatePage() {
     ?? "";
 
   const [form, setForm] = useState({
-    first_name: "",
-    last_name: "",
-    email: "",
-    phone: "",
-    dob: "",
-    gender: "",
-    programme: "",
-    intake: "",
-    sponsorship_type: "",
+    first_name: "", last_name: "", other_names: "",
+    email: "", phone: "", dob: "", gender: "",
+    nin: "", nationality: "Ugandan", marital_status: "",
+    district_of_origin: "", residency_type: "",
+    programme: "", intake: "", sponsorship_type: "",
+    // Guardian
+    guardian_name: "", guardian_phone: "", guardian_relationship: "",
+    // Prior qualifications
+    previous_school: "", previous_award: "", year_of_completion: "",
+    uvtab_index: "", uvtab_year: "", uvtab_centre: "",
   });
   const [programmeType, setProgrammeType] = useState<ProgrammeType | "">("");
   const [saving, setSaving] = useState(false);
@@ -71,6 +80,24 @@ export function ApplicationCreatePage() {
     setSaving(true);
     setError(null);
     try {
+      // Build extension from additional fields
+      const extension: Record<string, string> = {};
+      if (form.other_names)          extension.other_names = form.other_names;
+      if (form.nin)                  extension.nin = form.nin;
+      if (form.nationality)          extension.nationality = form.nationality;
+      if (form.marital_status)       extension.marital_status = form.marital_status;
+      if (form.district_of_origin)   extension.district_of_origin = form.district_of_origin;
+      if (form.residency_type)       extension.residency_type = form.residency_type;
+      if (form.guardian_name)        extension.guardian_name = form.guardian_name;
+      if (form.guardian_phone)       extension.guardian_phone = form.guardian_phone;
+      if (form.guardian_relationship) extension.guardian_relationship = form.guardian_relationship;
+      if (form.previous_school)      extension.previous_school = form.previous_school;
+      if (form.previous_award)       extension.previous_award = form.previous_award;
+      if (form.year_of_completion)   extension.year_of_completion = form.year_of_completion;
+      if (form.uvtab_index)          extension.uvtab_index = form.uvtab_index;
+      if (form.uvtab_year)           extension.uvtab_year = form.uvtab_year;
+      if (form.uvtab_centre)         extension.uvtab_centre = form.uvtab_centre;
+
       const body = {
         first_name: form.first_name,
         last_name: form.last_name,
@@ -81,6 +108,7 @@ export function ApplicationCreatePage() {
         email: form.email || undefined,
         phone: form.phone || undefined,
         sponsorship_type: form.sponsorship_type || undefined,
+        extension: Object.keys(extension).length > 0 ? extension : undefined,
       };
       const result = await createApplication(body);
       navigate(`/admissions/${result.application.id}`);
@@ -112,22 +140,16 @@ export function ApplicationCreatePage() {
         >
           <div style={twoColGrid}>
             <Field label="First Name" required>
-              <input
-                required
-                style={inputCss}
-                value={form.first_name}
-                onChange={(e) => set("first_name", e.target.value)}
-              />
+              <input required style={inputCss} value={form.first_name} onChange={(e) => set("first_name", e.target.value)} />
             </Field>
             <Field label="Last Name" required>
-              <input
-                required
-                style={inputCss}
-                value={form.last_name}
-                onChange={(e) => set("last_name", e.target.value)}
-              />
+              <input required style={inputCss} value={form.last_name} onChange={(e) => set("last_name", e.target.value)} />
             </Field>
           </div>
+
+          <Field label="Other Names (Middle Name)">
+            <input style={inputCss} value={form.other_names} onChange={(e) => set("other_names", e.target.value)} placeholder="Optional" />
+          </Field>
 
           <div style={twoColGrid}>
             <Field label="Email">
@@ -150,25 +172,44 @@ export function ApplicationCreatePage() {
 
           <div style={twoColGrid}>
             <Field label="Date of Birth">
-              <input
-                type="date"
-                style={inputCss}
-                value={form.dob}
-                onChange={(e) => set("dob", e.target.value)}
-              />
+              <input type="date" style={inputCss} value={form.dob} onChange={(e) => set("dob", e.target.value)} />
             </Field>
             <Field label="Gender">
-              <select
-                style={selectCss}
-                value={form.gender}
-                onChange={(e) => set("gender", e.target.value)}
-              >
+              <select style={selectCss} value={form.gender} onChange={(e) => set("gender", e.target.value)}>
                 <option value="">— Select —</option>
                 <option value="Male">Male</option>
                 <option value="Female">Female</option>
               </select>
             </Field>
           </div>
+
+          <div style={twoColGrid}>
+            <Field label="National ID / NIN">
+              <input style={inputCss} value={form.nin} onChange={(e) => set("nin", e.target.value)} placeholder="CM91234567890" />
+            </Field>
+            <Field label="Nationality">
+              <input style={inputCss} value={form.nationality} onChange={(e) => set("nationality", e.target.value)} />
+            </Field>
+          </div>
+
+          <div style={twoColGrid}>
+            <Field label="Marital Status">
+              <select style={selectCss} value={form.marital_status} onChange={(e) => set("marital_status", e.target.value)}>
+                <option value="">— Select —</option>
+                {MARITAL_STATUSES.map((s) => <option key={s} value={s}>{s}</option>)}
+              </select>
+            </Field>
+            <Field label="District of Origin">
+              <input style={inputCss} value={form.district_of_origin} onChange={(e) => set("district_of_origin", e.target.value)} placeholder="e.g. Kampala" />
+            </Field>
+          </div>
+
+          <Field label="Residency">
+            <select style={selectCss} value={form.residency_type} onChange={(e) => set("residency_type", e.target.value)}>
+              <option value="">— Select —</option>
+              {RESIDENCY_TYPES.map((r) => <option key={r} value={r}>{r}</option>)}
+            </select>
+          </Field>
 
           <div style={twoColGrid}>
             <Field label="Programme Type">
@@ -204,34 +245,61 @@ export function ApplicationCreatePage() {
           </div>
 
           <Field label="Intake" required>
-              <select
-                required
-                style={selectCss}
-                value={form.intake || defaultIntake}
-                onChange={(e) => set("intake", e.target.value)}
-              >
+              <select required style={selectCss} value={form.intake || defaultIntake} onChange={(e) => set("intake", e.target.value)}>
                 <option value="">— Select Intake —</option>
                 {(academicYears ?? []).map((y) => (
-                  <option key={y.id} value={y.name}>
-                    {y.name}{y.is_current ? " (Current)" : ""}
-                  </option>
+                  <option key={y.id} value={y.name}>{y.name}{y.is_current ? " (Current)" : ""}</option>
                 ))}
               </select>
             </Field>
 
           <Field label="Sponsorship Type">
-            <select
-              style={selectCss}
-              value={form.sponsorship_type}
-              onChange={(e) => set("sponsorship_type", e.target.value)}
-            >
+            <select style={selectCss} value={form.sponsorship_type} onChange={(e) => set("sponsorship_type", e.target.value)}>
               <option value="">— Select —</option>
-              {SPONSORSHIP_TYPES.map((s) => (
-                <option key={s} value={s}>
-                  {s}
-                </option>
-              ))}
+              {SPONSORSHIP_TYPES.map((s) => <option key={s} value={s}>{s}</option>)}
             </select>
+          </Field>
+
+          {/* Guardian / Parent Information */}
+          <div style={sectionHeading}>Guardian / Parent Information</div>
+          <div style={twoColGrid}>
+            <Field label="Guardian / Parent Name">
+              <input style={inputCss} value={form.guardian_name} onChange={(e) => set("guardian_name", e.target.value)} placeholder="Full name" />
+            </Field>
+            <Field label="Guardian Phone">
+              <input type="tel" style={inputCss} value={form.guardian_phone} onChange={(e) => set("guardian_phone", e.target.value)} />
+            </Field>
+          </div>
+          <Field label="Relationship to Applicant">
+            <input style={inputCss} value={form.guardian_relationship} onChange={(e) => set("guardian_relationship", e.target.value)} placeholder="e.g. Father, Mother, Uncle" />
+          </Field>
+
+          {/* Previous Qualifications */}
+          <div style={sectionHeading}>Previous Qualifications</div>
+          <div style={twoColGrid}>
+            <Field label="Previous School / Institution">
+              <input style={inputCss} value={form.previous_school} onChange={(e) => set("previous_school", e.target.value)} />
+            </Field>
+            <Field label="Qualification Obtained">
+              <input style={inputCss} value={form.previous_award} onChange={(e) => set("previous_award", e.target.value)} placeholder="e.g. UCE, UACE" />
+            </Field>
+          </div>
+          <Field label="Year of Completion">
+            <input style={inputCss} value={form.year_of_completion} onChange={(e) => set("year_of_completion", e.target.value)} placeholder="e.g. 2023" />
+          </Field>
+
+          {/* UVTAB / Exams */}
+          <div style={sectionHeading}>UVTAB / Examination Results</div>
+          <div style={twoColGrid}>
+            <Field label="UVTAB Index Number">
+              <input style={inputCss} value={form.uvtab_index} onChange={(e) => set("uvtab_index", e.target.value)} placeholder="e.g. U0001/001/2023" />
+            </Field>
+            <Field label="Year of Examination">
+              <input style={inputCss} value={form.uvtab_year} onChange={(e) => set("uvtab_year", e.target.value)} placeholder="e.g. 2023" />
+            </Field>
+          </div>
+          <Field label="Examination Centre">
+            <input style={inputCss} value={form.uvtab_centre} onChange={(e) => set("uvtab_centre", e.target.value)} />
           </Field>
 
           {error && <ErrorBanner message={error} />}

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -41,6 +41,7 @@ import { DashboardWidgetsEditor } from "./admin-studio/DashboardWidgetsEditor";
 import { ReceiptTemplateEditor } from "./admin-studio/ReceiptTemplateEditor";
 import { AssessmentTypesEditor } from "./admin-studio/AssessmentTypesEditor";
 import { FeeTypesEditor } from "./admin-studio/FeeTypesEditor";
+import { DepartmentsEditor } from "./admin-studio/DepartmentsEditor";
 import { VtiSetupPage as _VtiSetupPage } from "./setup/VtiSetupPage"; // kept for platform admin
 import { SetupClosedPage } from "./setup/SetupClosedPage";
 import { PlatformAdminLayout } from "./platform-admin/PlatformAdminLayout";
@@ -269,6 +270,7 @@ export const router = createBrowserRouter([
       { path: "receipt-template", element: <ReceiptTemplateEditor /> },
       { path: "assessment-types", element: <AssessmentTypesEditor /> },
       { path: "fee-types", element: <FeeTypesEditor /> },
+      { path: "departments", element: <DepartmentsEditor /> },
     ],
   },
 ]);


### PR DESCRIPTION
## Summary

Closes #227
Closes #219

---

### #227 - Custom Departments (Admin Studio)

- **New DepartmentsEditor** in Admin Studio allows admins to add/remove department labels
- Saved to config.institution.departments via the config versioning system (draft ? publish)
- Default departments pre-populated: ICT, Business, Engineering, Construction, Electrical, Automotive, Hospitality, Agriculture, Health Sciences, Others
- ProgrammesListPage already reads from useConfig().departments - no change needed there

### #219 - Missing Application Fields (P2 High)

Added to the **Create Application** form:

| Field | Section |
|---|---|
| Other Names (middle name) | Personal |
| National ID / NIN | Personal |
| Nationality | Personal |
| Marital Status | Personal |
| District of Origin | Personal |
| Residency Type | Personal |
| Guardian / Parent Name | Guardian |
| Guardian Phone | Guardian |
| Relationship to Applicant | Guardian |
| Previous School / Institution | Previous Qualifications |
| Qualification Obtained | Previous Qualifications |
| Year of Completion | Previous Qualifications |
| UVTAB Index Number | UVTAB / Exams |
| Year of Examination | UVTAB / Exams |
| Examination Centre | UVTAB / Exams |

All extra fields are stored in the existing extension JSONB column - **no DB migration required**.

ApplicationDetailPage already has a collapsible **Additional Details** section that renders all extension fields automatically.

---

### Testing

- No new API endpoints - existing POST /admissions/applications accepts extension JSON
- No DB migration needed
- TypeScript: no errors