### PR TITLE
feat(#235): bulk course import via xlsx/csv

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -24,6 +24,7 @@
     "nodemailer": "^8.0.10",
     "pg": "^8.13.3",
     "resend": "^6.12.4",
+    "xlsx": "^0.18.5",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/apps/api/src/modules/courses/courses.routes.ts
+++ b/apps/api/src/modules/courses/courses.routes.ts
@@ -1,4 +1,5 @@
 import type { FastifyInstance } from "fastify";
+import * as XLSX from "xlsx";
 import { withTenant } from "../../db/tenant.js";
 import { requireRole } from "../../middleware/requireRole.js";
 import { getTenantId } from "../../lib/tenantId.js";
@@ -328,6 +329,150 @@ export async function coursesRoutes(app: FastifyInstance) {
         return reply.status(404).send({ error: "course offering not found" });
 
       return row.rows[0];
+    },
+  );
+
+  // ======================== Course Import ========================
+
+  // GET /courses/import/template  — returns a blank xlsx template
+  app.get(
+    "/courses/import/template",
+    { preHandler: requireRole(...WRITE_ROLES) },
+    async (_req, reply) => {
+      const wb = XLSX.utils.book_new();
+      const headers = [
+        ["programme_code", "code", "title", "credit_hours", "course_type", "year_of_study", "semester", "description"],
+      ];
+      const ws = XLSX.utils.aoa_to_sheet(headers);
+      // Column widths
+      ws["!cols"] = [16, 14, 36, 14, 18, 16, 10, 40].map((w) => ({ wch: w }));
+      XLSX.utils.book_append_sheet(wb, ws, "Courses");
+      const buf = XLSX.write(wb, { type: "buffer", bookType: "xlsx" });
+      reply
+        .header("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+        .header("Content-Disposition", 'attachment; filename="courses_import_template.xlsx"')
+        .send(buf);
+    },
+  );
+
+  // POST /courses/import  — multipart xlsx/csv, inserts rows for this tenant
+  app.post(
+    "/courses/import",
+    { preHandler: requireRole(...WRITE_ROLES) },
+    async (req, reply) => {
+      const tid = getTenantId(req);
+      if (!tid)
+        return reply.status(400).send({ error: "x-tenant-id header required" });
+
+      const data = await req.file();
+      if (!data)
+        return reply.status(400).send({ error: "No file uploaded" });
+
+      const mime = data.mimetype;
+      const allowed = [
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/vnd.ms-excel",
+        "text/csv",
+        "application/octet-stream",
+      ];
+      if (!allowed.includes(mime) && !data.filename?.match(/\.(xlsx|xls|csv)$/i)) {
+        return reply.status(400).send({ error: "Only xlsx/xls/csv files are accepted" });
+      }
+
+      const chunks: Buffer[] = [];
+      for await (const chunk of data.file) {
+        chunks.push(chunk as Buffer);
+      }
+      const buf = Buffer.concat(chunks);
+
+      let rows: Record<string, unknown>[];
+      try {
+        const wb = XLSX.read(buf, { type: "buffer" });
+        const ws = wb.Sheets[wb.SheetNames[0]];
+        rows = XLSX.utils.sheet_to_json<Record<string, unknown>>(ws, { defval: "" });
+      } catch {
+        return reply.status(400).send({ error: "Could not parse file — ensure it is a valid xlsx or csv" });
+      }
+
+      if (rows.length === 0)
+        return reply.status(422).send({ error: "File has no data rows" });
+
+      if (rows.length > 500)
+        return reply.status(422).send({ error: "Max 500 rows per import" });
+
+      // Resolve programme_code → programme_id within this tenant
+      const progCodes = [...new Set(rows.map((r) => String(r.programme_code ?? "").trim()).filter(Boolean))];
+      if (progCodes.length === 0)
+        return reply.status(422).send({ error: "programme_code column is required" });
+
+      const progResult = await withTenant(tid, (client) =>
+        client.query(
+          `SELECT id, code FROM app.programmes WHERE code = ANY($1)`,
+          [progCodes],
+        ),
+      );
+      const progMap = new Map<string, string>(
+        progResult.rows.map((r: { id: string; code: string }) => [r.code, r.id]),
+      );
+
+      const imported: string[] = [];
+      const skipped: { row: number; reason: string }[] = [];
+
+      for (let i = 0; i < rows.length; i++) {
+        const r = rows[i];
+        const rowNum = i + 2; // 1-based + header
+
+        const progCode = String(r.programme_code ?? "").trim();
+        const code = String(r.code ?? "").trim().toUpperCase();
+        const title = String(r.title ?? "").trim();
+
+        if (!progCode || !code || !title) {
+          skipped.push({ row: rowNum, reason: "programme_code, code and title are required" });
+          continue;
+        }
+
+        const progId = progMap.get(progCode);
+        if (!progId) {
+          skipped.push({ row: rowNum, reason: `Programme '${progCode}' not found` });
+          continue;
+        }
+
+        const creditHours = Number(r.credit_hours) || 3;
+        const courseType = ["theory", "practical", "both"].includes(String(r.course_type))
+          ? String(r.course_type)
+          : "theory";
+        const yearOfStudy = Number(r.year_of_study) || 1;
+        const semester = Number(r.semester) || 1;
+
+        try {
+          await withTenant(tid, (client) =>
+            client.query(
+              `INSERT INTO app.courses
+                 (tenant_id, programme_id, code, title, credit_hours, course_type, year_of_study, semester)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+               ON CONFLICT (tenant_id, code) DO UPDATE
+                 SET programme_id = EXCLUDED.programme_id,
+                     title = EXCLUDED.title,
+                     credit_hours = EXCLUDED.credit_hours,
+                     course_type = EXCLUDED.course_type,
+                     year_of_study = EXCLUDED.year_of_study,
+                     semester = EXCLUDED.semester,
+                     updated_at = now()`,
+              [tid, progId, code, title, creditHours, courseType, yearOfStudy, semester],
+            ),
+          );
+          imported.push(code);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : "db error";
+          skipped.push({ row: rowNum, reason: msg });
+        }
+      }
+
+      return reply.status(200).send({
+        imported: imported.length,
+        skipped: skipped.length,
+        details: skipped,
+      });
     },
   );
 }

--- a/apps/web/src/lib/apiFetch.ts
+++ b/apps/web/src/lib/apiFetch.ts
@@ -31,11 +31,14 @@ async function doFetch(
     ? { Authorization: `Bearer ${accessToken}`, "x-tenant-id": tenantId }
     : { "x-tenant-id": tenantId, "x-dev-role": devRole };
 
-  // Only send Content-Type: application/json when there is a body.
+  // Only send Content-Type: application/json when there is a body and it is
+  // NOT a FormData (multipart uploads set their own Content-Type boundary).
   // Fastify 4 rejects requests that declare application/json but have an
   // empty body (FST_ERR_CTP_EMPTY_JSON_BODY → 400).
   const contentTypeHeader: Record<string, string> =
-    init?.body != null ? { "Content-Type": "application/json" } : {};
+    init?.body != null && !(init.body instanceof FormData)
+      ? { "Content-Type": "application/json" }
+      : {};
 
   return fetch(`${BASE_URL}${path}`, {
     ...init,

--- a/apps/web/src/modules/courses/courses.api.ts
+++ b/apps/web/src/modules/courses/courses.api.ts
@@ -1,4 +1,5 @@
 import { apiFetch } from "../../lib/apiFetch";
+import { getAccessToken } from "../../lib/auth";
 
 export interface Course {
   id: string;
@@ -67,5 +68,40 @@ export function updateCourse(id: string, body: UpdateCourseBody): Promise<Course
   return apiFetch<Course>(`/courses/${id}`, {
     method: "PATCH",
     body: JSON.stringify(body),
+  });
+}
+
+export interface CourseImportResult {
+  imported: number;
+  skipped: number;
+  details: { row: number; reason: string }[];
+}
+
+export async function downloadCourseTemplate(): Promise<void> {
+  const token = getAccessToken();
+  const tid = localStorage.getItem("amis_tenant_id") ?? "";
+  const devRole = localStorage.getItem("amis_dev_role") ?? "admin";
+  const base = import.meta.env.VITE_API_URL ?? "http://localhost:3000";
+  const authHeaders: Record<string, string> = token
+    ? { Authorization: `Bearer ${token}`, "x-tenant-id": tid }
+    : { "x-tenant-id": tid, "x-dev-role": devRole };
+
+  const r = await fetch(`${base}/courses/import/template`, { headers: authHeaders });
+  if (!r.ok) throw new Error("Failed to download template");
+  const blob = await r.blob();
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "courses_import_template.xlsx";
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export async function importCourses(file: File): Promise<CourseImportResult> {
+  const form = new FormData();
+  form.append("file", file);
+  return apiFetch<CourseImportResult>("/courses/import", {
+    method: "POST",
+    body: form,
   });
 }

--- a/apps/web/src/modules/programmes/ProgrammeDetailPage.tsx
+++ b/apps/web/src/modules/programmes/ProgrammeDetailPage.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { getProgramme, updateProgramme, deleteProgramme, type UpdateProgrammeBody } from "./programmes.api";
-import { listCourses, createCourse, deleteCourse, updateCourse, type CreateCourseBody, type UpdateCourseBody, type Course } from "../courses/courses.api";
+import { listCourses, createCourse, deleteCourse, updateCourse, importCourses, downloadCourseTemplate, type CreateCourseBody, type UpdateCourseBody, type Course } from "../courses/courses.api";
 import { useConfig } from "../../app/ConfigProvider";
 import {
   ensureGlobalCss,
@@ -55,6 +55,9 @@ export function ProgrammeDetailPage() {
 
   // Courses sub-section state
   const [addingCourse, setAddingCourse] = useState(false);
+  const [importing, setImporting] = useState(false);
+  const [importResult, setImportResult] = useState<{ imported: number; skipped: number; details: { row: number; reason: string }[] } | null>(null);
+  const [importError, setImportError] = useState<string | null>(null);
   const [courseForm, setCourseForm] = useState<{
     code: string; title: string; credit_hours: string;
     course_type: "theory" | "practical" | "both"; year_of_study: string; semester: string;
@@ -258,7 +261,54 @@ export function ProgrammeDetailPage() {
             Courses ({courses.length})
           </h2>
           {!addingCourse && (
-            <SecondaryBtn onClick={() => setAddingCourse(true)}>+ Add Course</SecondaryBtn>
+            <div style={{ display: "flex", gap: 8 }}>
+              <SecondaryBtn onClick={() => { void downloadCourseTemplate().catch((e) => alert(String(e))); }}>↓ Template</SecondaryBtn>
+              <label style={{ cursor: "pointer" }}>
+                <span style={{
+                  display: "inline-block", padding: "6px 14px", fontSize: 13,
+                  border: "1px solid #d1d5db", borderRadius: 6, background: "#fff",
+                  color: "#374151", lineHeight: "20px", userSelect: "none",
+                }}>
+                  {importing ? "Importing…" : "↑ Import xlsx"}
+                </span>
+                <input
+                  type="file" accept=".xlsx,.xls,.csv" style={{ display: "none" }}
+                  onChange={async (e) => {
+                    const file = e.target.files?.[0];
+                    if (!file) return;
+                    setImporting(true); setImportResult(null); setImportError(null);
+                    try {
+                      const res = await importCourses(file);
+                      setImportResult(res);
+                      qc.invalidateQueries({ queryKey: ["courses", id] });
+                    } catch (err) {
+                      setImportError(err instanceof Error ? err.message : "Import failed");
+                    } finally {
+                      setImporting(false);
+                      e.target.value = "";
+                    }
+                  }}
+                />
+              </label>
+              <SecondaryBtn onClick={() => setAddingCourse(true)}>+ Add Course</SecondaryBtn>
+            </div>
+          )}
+          {importError && <ErrorBanner message={importError} />}
+          {importResult && (
+            <div style={{ fontSize: 13, padding: "8px 12px", background: importResult.skipped > 0 ? "#fefce8" : "#f0fdf4",
+              border: `1px solid ${importResult.skipped > 0 ? "#fde047" : "#86efac"}`, borderRadius: 6, marginBottom: 12 }}>
+              <strong>{importResult.imported} course{importResult.imported !== 1 ? "s" : ""} imported</strong>
+              {importResult.skipped > 0 && (
+                <>
+                  {" "}&mdash; {importResult.skipped} skipped:
+                  <ul style={{ margin: "4px 0 0 16px", padding: 0 }}>
+                    {importResult.details.map((d) => (
+                      <li key={d.row}>Row {d.row}: {d.reason}</li>
+                    ))}
+                  </ul>
+                </>
+              )}
+            </div>
           )}
         </div>
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ importers:
       resend:
         specifier: ^6.12.4
         version: 6.12.4
+      xlsx:
+        specifier: ^0.18.5
+        version: 0.18.5
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -1299,6 +1302,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  adler-32@1.3.1:
+    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
+    engines: {node: '>=0.8'}
+
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
@@ -1428,6 +1435,10 @@ packages:
   caniuse-lite@1.0.30001797:
     resolution: {integrity: sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==}
 
+  cfb@1.2.2:
+    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
+    engines: {node: '>=0.8'}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -1435,6 +1446,10 @@ packages:
   cluster-key-slot@1.1.2:
     resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
     engines: {node: '>=0.10.0'}
+
+  codepage@1.15.0:
+    resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
+    engines: {node: '>=0.8'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -1460,6 +1475,11 @@ packages:
 
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
@@ -1662,6 +1682,10 @@ packages:
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
+
+  frac@1.1.2:
+    resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
+    engines: {node: '>=0.8'}
 
   fs-extra@9.1.0:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
@@ -2504,6 +2528,10 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  ssf@0.11.2:
+    resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
+    engines: {node: '>=0.8'}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -2810,6 +2838,14 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  wmf@1.0.2:
+    resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
+    engines: {node: '>=0.8'}
+
+  word@0.3.0:
+    resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
+    engines: {node: '>=0.8'}
+
   workbox-background-sync@7.4.1:
     resolution: {integrity: sha512-HhT7KE8tOWDm02wRNshXUnUPofMlhenF2DBdUnDPOubhizzPeItkYTmAB6td1Z2cjYPa98vzEiPLEuzn5hN66g==}
 
@@ -2861,6 +2897,11 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  xlsx@0.18.5:
+    resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -4082,6 +4123,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  adler-32@1.3.1: {}
+
   ajv-formats@2.1.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
@@ -4220,9 +4263,16 @@ snapshots:
 
   caniuse-lite@1.0.30001797: {}
 
+  cfb@1.2.2:
+    dependencies:
+      adler-32: 1.3.1
+      crc-32: 1.2.2
+
   chai@6.2.2: {}
 
   cluster-key-slot@1.1.2: {}
+
+  codepage@1.15.0: {}
 
   commander@2.20.3: {}
 
@@ -4241,6 +4291,8 @@ snapshots:
   core-js-compat@3.49.0:
     dependencies:
       browserslist: 4.28.2
+
+  crc-32@1.2.2: {}
 
   cron-parser@4.9.0:
     dependencies:
@@ -4522,6 +4574,8 @@ snapshots:
       signal-exit: 4.1.0
 
   forwarded@0.2.0: {}
+
+  frac@1.1.2: {}
 
   fs-extra@9.1.0:
     dependencies:
@@ -5391,6 +5445,10 @@ snapshots:
 
   split2@4.2.0: {}
 
+  ssf@0.11.2:
+    dependencies:
+      frac: 1.1.2
+
   stackback@0.0.2: {}
 
   standard-as-callback@2.1.0: {}
@@ -5698,6 +5756,10 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wmf@1.0.2: {}
+
+  word@0.3.0: {}
+
   workbox-background-sync@7.4.1:
     dependencies:
       idb: 7.1.1
@@ -5812,6 +5874,16 @@ snapshots:
       workbox-core: 7.4.1
 
   wrappy@1.0.2: {}
+
+  xlsx@0.18.5:
+    dependencies:
+      adler-32: 1.3.1
+      cfb: 1.2.2
+      codepage: 1.15.0
+      crc-32: 1.2.2
+      ssf: 0.11.2
+      wmf: 1.0.2
+      word: 0.3.0
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
## Summary

Closes #235

---

### Changes

**API (pps/api)**
- GET /courses/import/template - returns a blank .xlsx file with columns: programme_code, code, 	itle, credit_hours, course_type, year_of_study, semester, description
- POST /courses/import - accepts multipart file upload (.xlsx, .xls, .csv), parses with SheetJS, resolves programme_code ? programme_id per tenant, upserts on (tenant_id, code) conflict
- Returns { imported, skipped, details } - per-row error details for skipped rows
- Max 500 rows per import; unknown programme codes reported per-row
- Added xlsx dependency (SheetJS)

**Web (pps/web)**
- ProgrammeDetailPage: added **? Template** and **? Import xlsx** buttons alongside existing + Add Course
- Import result shown inline (green success / yellow with skipped row details)
- piFetch: skip Content-Type: application/json for FormData bodies (fixes multipart uploads)

### No DB migration required
Upserts to existing pp.courses table.

### Testing
- TypeScript: no errors
- Upload .xlsx with programme_code column matching existing programmes ? courses created/updated
- Unknown programme_code ? skipped with reason message