### PR TITLE
feat(#229, #225): TVET assessment types + 11-step sequential clearance

### DIFF
--- a/apps/api/src/modules/clearance/clearance.routes.ts
+++ b/apps/api/src/modules/clearance/clearance.routes.ts
@@ -7,6 +7,8 @@ import {
   SignOffSchema,
   ClearanceQuerySchema,
   DEPARTMENTS,
+  DEPT_STEP,
+  CLEARANCE_STEPS,
 } from "./clearance.schema.js";
 
 // ---------------------------------------------------------------------------
@@ -374,6 +376,32 @@ export async function clearanceRoutes(app: FastifyInstance) {
               } as const;
             }
           }
+
+          // Enforce sequential ordering: all prior steps must be SIGNED
+          const currentStep = DEPT_STEP[department];
+          if (currentStep !== undefined && currentStep > 1) {
+            const { rows: priorRows } = await client.query<{
+              department: string;
+              status: string;
+            }>(
+              `SELECT department, status FROM app.clearance_signoffs
+               WHERE tenant_id = $1 AND student_id = $2 AND term_id = $3`,
+              [tid, student_id, term_id],
+            );
+            const priorSigned = new Set(
+              priorRows.filter((r) => r.status === "SIGNED").map((r) => r.department),
+            );
+            // Find the first previous sequential step that is not yet SIGNED
+            const blocker = CLEARANCE_STEPS.find(
+              (s) => s.step < currentStep && !priorSigned.has(s.dept),
+            );
+            if (blocker) {
+              return {
+                sequentialBlocked: true,
+                message: `Step ${blocker.step} (${blocker.label}) must be completed before signing off this step.`,
+              } as const;
+            }
+          }
         }
 
         // Upsert sign-off
@@ -396,6 +424,8 @@ export async function clearanceRoutes(app: FastifyInstance) {
       if (row && "notFound" in row)
         return reply.status(404).send({ error: row.message });
       if (row && "eligibilityFailed" in row)
+        return reply.status(422).send({ error: row.message });
+      if (row && "sequentialBlocked" in row)
         return reply.status(422).send({ error: row.message });
 
       return reply.status(201).send(row);

--- a/apps/api/src/modules/clearance/clearance.schema.ts
+++ b/apps/api/src/modules/clearance/clearance.schema.ts
@@ -1,22 +1,58 @@
 import { z } from "zod";
 
-export const DEPARTMENTS = [
-  "store",
-  "library",
-  "sports",
-  "warden",
-  "hod",
-  "dean_of_students",
-  "accounts",
-  "academic_registrar",
+/**
+ * Ordered 11-step clearance sequence (UTC Kyema / UVTAB standard).
+ *
+ * Each step must be SIGNED before the next can be actioned.
+ * `roles` lists which AMIS roles are permitted to perform the sign-off.
+ */
+export const CLEARANCE_STEPS = [
+  { step: 1,  dept: "academic_registrar",        label: "Academic Registrar",            roles: ["registrar", "admin"] },
+  { step: 2,  dept: "accounts",                  label: "Accountant / Finance",          roles: ["finance", "admin"] },
+  { step: 3,  dept: "warden",                    label: "Warden / Custodian",            roles: ["admin", "registrar"] },
+  { step: 4,  dept: "store",                     label: "Stores",                        roles: ["admin", "registrar"] },
+  { step: 5,  dept: "catering",                  label: "Catering Officer",              roles: ["admin", "registrar"] },
+  { step: 6,  dept: "hod",                       label: "Head of Department",            roles: ["hod", "admin"] },
+  { step: 7,  dept: "dean_of_students",          label: "Dean of Students",              roles: ["dean", "admin"] },
+  { step: 8,  dept: "nurse",                     label: "Nurse / Health",                roles: ["admin", "registrar"] },
+  { step: 9,  dept: "library",                   label: "Library",                       roles: ["admin", "registrar"] },
+  { step: 10, dept: "ict_technician",            label: "ICT Technician",                roles: ["admin", "registrar"] },
+  { step: 11, dept: "academic_registrar_final",  label: "Academic Registrar (Final)",    roles: ["registrar", "admin"] },
 ] as const;
 
-export type Department = (typeof DEPARTMENTS)[number];
+/** Optional legacy department kept for backward-compat; not in the sequential steps */
+export const OPTIONAL_DEPARTMENTS = ["sports"] as const;
+
+export const DEPARTMENTS = CLEARANCE_STEPS.map((s) => s.dept) as unknown as [
+  "academic_registrar",
+  "accounts",
+  "warden",
+  "store",
+  "catering",
+  "hod",
+  "dean_of_students",
+  "nurse",
+  "library",
+  "ict_technician",
+  "academic_registrar_final",
+];
+
+export type Department = typeof DEPARTMENTS[number];
+
+/** Map dept key → step number for quick lookup */
+export const DEPT_STEP: Record<string, number> = Object.fromEntries(
+  CLEARANCE_STEPS.map((s) => [s.dept, s.step]),
+);
+
+/** Map dept key → display label */
+export const DEPT_LABEL: Record<string, string> = Object.fromEntries(
+  CLEARANCE_STEPS.map((s) => [s.dept, s.label]),
+);
 
 export const SignOffSchema = z.object({
   student_id: z.string().uuid(),
   term_id: z.string().uuid(),
-  department: z.enum(DEPARTMENTS),
+  department: z.string().min(1),
   status: z.enum(["SIGNED", "REJECTED"]),
   remarks: z.string().optional(),
 });
@@ -30,3 +66,4 @@ export const ClearanceQuerySchema = z.object({
 
 export type SignOff = z.infer<typeof SignOffSchema>;
 export type ClearanceQuery = z.infer<typeof ClearanceQuerySchema>;
+

--- a/apps/api/src/modules/clearance/clearance.schema.ts
+++ b/apps/api/src/modules/clearance/clearance.schema.ts
@@ -49,10 +49,19 @@ export const DEPT_LABEL: Record<string, string> = Object.fromEntries(
   CLEARANCE_STEPS.map((s) => [s.dept, s.label]),
 );
 
+/** All valid department keys (sequential steps + legacy optional) */
+export const ALL_VALID_DEPARTMENTS = new Set<string>([
+  ...CLEARANCE_STEPS.map((s) => s.dept),
+  ...OPTIONAL_DEPARTMENTS,
+]);
+
 export const SignOffSchema = z.object({
   student_id: z.string().uuid(),
   term_id: z.string().uuid(),
-  department: z.string().min(1),
+  department: z.string().min(1).refine(
+    (d) => ALL_VALID_DEPARTMENTS.has(d),
+    (d) => ({ message: `Unknown department: "${d}". Must be one of: ${[...ALL_VALID_DEPARTMENTS].join(", ")}` }),
+  ),
   status: z.enum(["SIGNED", "REJECTED"]),
   remarks: z.string().optional(),
 });

--- a/apps/api/src/modules/marks/marks.schema.ts
+++ b/apps/api/src/modules/marks/marks.schema.ts
@@ -3,8 +3,32 @@ import { z } from "zod";
 export const VALID_TERMS = ["Term 1", "Term 2", "Term 3"] as const;
 export type ValidTerm = (typeof VALID_TERMS)[number];
 
-export const ASSESSMENT_TYPES = ["midterm", "end_of_term", "coursework", "practical"] as const;
+export const ASSESSMENT_TYPES = [
+  // TVET standard types (UVTAB / UTC Kyema)
+  "assignment_1",
+  "assignment_2",
+  "test_1",
+  "test_2",
+  "practical_1",
+  "practical_2",
+  "end_of_term",
+  // Legacy / generic types
+  "midterm",
+  "coursework",
+  "practical",
+] as const;
 export type AssessmentType = (typeof ASSESSMENT_TYPES)[number];
+
+/** Standard TVET weights (%) per assessment component (UVTAB grading scheme). */
+export const TVET_WEIGHTS: Record<string, number> = {
+  assignment_1: 5,
+  assignment_2: 5,
+  test_1: 10,
+  test_2: 10,
+  practical_1: 25,
+  practical_2: 25,
+  end_of_term: 40,
+};
 
 export const CreateSubmissionSchema = z.object({
   course_id: z.string().min(1),

--- a/apps/web/src/modules/clearance/ClearancePage.tsx
+++ b/apps/web/src/modules/clearance/ClearancePage.tsx
@@ -25,16 +25,20 @@ import {
   C,
 } from "../../lib/ui";
 
-const DEPT_LABELS: Record<string, string> = {
-  store: "Store",
-  library: "Library",
-  sports: "Sports",
-  warden: "Warden",
-  hod: "Head of Department",
-  dean_of_students: "Dean of Students",
-  accounts: "Accounts (Finance)",
-  academic_registrar: "Academic Registrar",
-};
+/** Ordered 11-step clearance sequence (must match backend CLEARANCE_STEPS) */
+const CLEARANCE_STEPS_UI = [
+  { step: 1,  dept: "academic_registrar",        label: "Academic Registrar" },
+  { step: 2,  dept: "accounts",                  label: "Accountant / Finance" },
+  { step: 3,  dept: "warden",                    label: "Warden / Custodian" },
+  { step: 4,  dept: "store",                     label: "Stores" },
+  { step: 5,  dept: "catering",                  label: "Catering Officer" },
+  { step: 6,  dept: "hod",                       label: "Head of Department" },
+  { step: 7,  dept: "dean_of_students",          label: "Dean of Students" },
+  { step: 8,  dept: "nurse",                     label: "Nurse / Health" },
+  { step: 9,  dept: "library",                   label: "Library" },
+  { step: 10, dept: "ict_technician",            label: "ICT Technician" },
+  { step: 11, dept: "academic_registrar_final",  label: "Academic Registrar (Final)" },
+] as const;
 
 interface Term {
   id: string;
@@ -177,129 +181,185 @@ export function ClearancePage() {
         </Card>
       )}
 
-      {data && (
-        <Card style={{ padding: 20 }}>
-          <div
-            style={{
-              display: "flex",
-              justifyContent: "space-between",
-              alignItems: "center",
-              marginBottom: 16,
-            }}
-          >
-            <SectionLabel>
-              Departments ({data.completed}/{data.total})
-            </SectionLabel>
-            {data.fully_cleared && (
-              <Badge label="✅ FULLY CLEARED" color="green" />
-            )}
-          </div>
+      {data && (() => {
+        // Compute the active step: first step that is not SIGNED
+        const activeStep = CLEARANCE_STEPS_UI.find(
+          (s) => (data.departments[s.dept]?.status ?? "PENDING") !== "SIGNED",
+        )?.step ?? null;
 
-          <div style={{ display: "grid", gap: 12 }}>
-            {Object.entries(data.departments).map(([dept, info]) => (
-              <div
-                key={dept}
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "space-between",
-                  padding: "12px 16px",
-                  background:
-                    info.status === "SIGNED"
-                      ? "#dcfce7"
-                      : info.status === "REJECTED"
-                        ? "#fee2e2"
-                        : C.gray50,
-                  borderRadius: 8,
-                  border: `1px solid ${C.gray200}`,
-                }}
-              >
-                <div>
-                  <span style={{ fontWeight: 600 }}>
-                    {DEPT_LABELS[dept] ?? dept}
-                  </span>
-                  <Badge
-                    label={info.status}
-                    color={
-                      info.status === "SIGNED"
-                        ? "green"
-                        : info.status === "REJECTED"
-                          ? "yellow"
-                          : "gray"
-                    }
-                  />
-                  {info.remarks && (
-                    <div
-                      style={{
-                        fontSize: 12,
-                        color: C.gray500,
-                        marginTop: 2,
-                      }}
-                    >
-                      {info.remarks}
-                    </div>
-                  )}
-                  {info.signed_at && (
-                    <div style={{ fontSize: 11, color: C.gray400 }}>
-                      {new Date(info.signed_at).toLocaleString()}
-                    </div>
-                  )}
-                </div>
+        return (
+          <Card style={{ padding: 20 }}>
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                marginBottom: 16,
+              }}
+            >
+              <SectionLabel>
+                Clearance Progress ({data.completed}/{data.total} steps)
+              </SectionLabel>
+              {data.fully_cleared && (
+                <Badge label="✅ FULLY CLEARED" color="green" />
+              )}
+            </div>
 
-                {info.status !== "SIGNED" && (
-                  <div style={{ display: "flex", gap: 8 }}>
-                    <PrimaryBtn
-                      onClick={() =>
-                        signMut.mutate({ department: dept, status: "SIGNED" })
-                      }
-                      disabled={
-                        signMut.isPending ||
-                        (dept === "accounts" &&
-                          eligibility?.checks.fees_cleared.pass === false) ||
-                        (dept === "hod" &&
-                          eligibility?.checks.marks_complete.pass === false) ||
-                        (dept === "hod" &&
-                          eligibility?.checks.attendance_ok?.pass === false)
-                      }
-                      title={
-                        dept === "accounts" &&
-                        eligibility?.checks.fees_cleared.pass === false
-                          ? eligibility.checks.fees_cleared.detail
-                          : dept === "hod" &&
-                              eligibility?.checks.marks_complete.pass === false
-                            ? eligibility.checks.marks_complete.detail
-                            : dept === "hod" &&
-                                eligibility?.checks.attendance_ok?.pass === false
-                              ? eligibility.checks.attendance_ok.detail
-                              : undefined
-                      }
-                      style={{ fontSize: 12, padding: "4px 12px" }}
-                    >
-                      ✅ Sign
-                    </PrimaryBtn>
-                    <SecondaryBtn
-                      onClick={() => {
-                        const remarks = prompt("Rejection remarks:");
-                        if (remarks !== null) {
-                          signMut.mutate({
-                            department: dept,
-                            status: "REJECTED",
-                            remarks,
-                          });
+            <div style={{ display: "grid", gap: 10 }}>
+              {CLEARANCE_STEPS_UI.map((stepDef) => {
+                const info = data.departments[stepDef.dept] ?? {
+                  status: "PENDING",
+                  signed_by: null,
+                  signed_at: null,
+                  remarks: null,
+                };
+                const isSigned   = info.status === "SIGNED";
+                const isRejected = info.status === "REJECTED";
+                const isActive   = stepDef.step === activeStep;
+                const isBlocked  = !isSigned && !isRejected && !isActive;
+
+                const bgColor = isSigned
+                  ? "#dcfce7"
+                  : isRejected
+                    ? "#fee2e2"
+                    : isActive
+                      ? "#eff6ff"
+                      : C.gray50;
+                const borderColor = isSigned
+                  ? "#86efac"
+                  : isRejected
+                    ? "#fca5a5"
+                    : isActive
+                      ? "#93c5fd"
+                      : C.gray200;
+
+                return (
+                  <div
+                    key={stepDef.dept}
+                    style={{
+                      display: "flex",
+                      alignItems: "flex-start",
+                      justifyContent: "space-between",
+                      padding: "12px 16px",
+                      background: bgColor,
+                      borderRadius: 8,
+                      border: `1px solid ${borderColor}`,
+                      opacity: isBlocked ? 0.6 : 1,
+                    }}
+                  >
+                    <div style={{ display: "flex", alignItems: "flex-start", gap: 12 }}>
+                      {/* Step number indicator */}
+                      <div
+                        style={{
+                          width: 28,
+                          height: 28,
+                          borderRadius: "50%",
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: "center",
+                          fontSize: 12,
+                          fontWeight: 700,
+                          flexShrink: 0,
+                          marginTop: 1,
+                          background: isSigned
+                            ? "#16a34a"
+                            : isRejected
+                              ? "#dc2626"
+                              : isActive
+                                ? "#2563eb"
+                                : "#9ca3af",
+                          color: "#fff",
+                        }}
+                      >
+                        {isSigned ? "✓" : isRejected ? "✗" : isBlocked ? "🔒" : stepDef.step}
+                      </div>
+
+                      <div>
+                        <div style={{ fontWeight: 600, fontSize: 14 }}>
+                          Step {stepDef.step} · {stepDef.label}
+                        </div>
+                        <div style={{ fontSize: 12, color: C.gray500, marginTop: 2 }}>
+                          {isSigned && info.signed_at
+                            ? `Signed — ${new Date(info.signed_at).toLocaleString()}`
+                            : isRejected
+                              ? "Rejected"
+                              : isActive
+                                ? "Awaiting sign-off"
+                                : "Pending previous step"}
+                        </div>
+                        {info.remarks && (
+                          <div style={{ fontSize: 12, color: C.gray400, marginTop: 2 }}>
+                            Remarks: {info.remarks}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+
+                    {/* Action buttons — only for active step */}
+                    {isActive && (
+                      <div style={{ display: "flex", gap: 8, flexShrink: 0 }}>
+                        <PrimaryBtn
+                          onClick={() =>
+                            signMut.mutate({ department: stepDef.dept, status: "SIGNED" })
+                          }
+                          disabled={
+                            signMut.isPending ||
+                            (stepDef.dept === "accounts" &&
+                              eligibility?.checks.fees_cleared.pass === false) ||
+                            (stepDef.dept === "hod" &&
+                              eligibility?.checks.marks_complete.pass === false)
+                          }
+                          title={
+                            stepDef.dept === "accounts" &&
+                            eligibility?.checks.fees_cleared.pass === false
+                              ? eligibility?.checks.fees_cleared.detail
+                              : stepDef.dept === "hod" &&
+                                  eligibility?.checks.marks_complete.pass === false
+                                ? eligibility?.checks.marks_complete.detail
+                                : undefined
+                          }
+                          style={{ fontSize: 12, padding: "4px 14px" }}
+                        >
+                          ✅ Sign
+                        </PrimaryBtn>
+                        <SecondaryBtn
+                          onClick={() => {
+                            const remarks = prompt("Rejection remarks:");
+                            if (remarks !== null) {
+                              signMut.mutate({
+                                department: stepDef.dept,
+                                status: "REJECTED",
+                                remarks,
+                              });
+                            }
+                          }}
+                          disabled={signMut.isPending}
+                          style={{ fontSize: 12, padding: "4px 12px" }}
+                        >
+                          ❌ Reject
+                        </SecondaryBtn>
+                      </div>
+                    )}
+
+                    {/* Re-sign button for rejected step */}
+                    {isRejected && (
+                      <PrimaryBtn
+                        onClick={() =>
+                          signMut.mutate({ department: stepDef.dept, status: "SIGNED" })
                         }
-                      }}
-                      disabled={signMut.isPending}
-                      style={{ fontSize: 12, padding: "4px 12px" }}
-                    >
-                      ❌ Reject
-                    </SecondaryBtn>
+                        disabled={signMut.isPending}
+                        style={{ fontSize: 12, padding: "4px 14px", flexShrink: 0 }}
+                      >
+                        Re-sign
+                      </PrimaryBtn>
+                    )}
                   </div>
-                )}
-              </div>
-            ))}
-          </div>
-        </Card>
-      )}
+                );
+              })}
+            </div>
+          </Card>
+        );
+      })()}
 
       {!statusQ.isLoading && !data && studentId && termId && (
         <EmptyState title="No clearance data. Click 'Init Clearance' to create sign-off records." />

--- a/apps/web/src/modules/marks/BulkMarkEntryPage.tsx
+++ b/apps/web/src/modules/marks/BulkMarkEntryPage.tsx
@@ -18,11 +18,18 @@ import {
   C,
 } from "../../lib/ui";
 
+/** UVTAB / UTC Kyema TVET standard assessment types */
 const DEFAULT_ASSESSMENT_TYPES = [
-  { value: "end_of_term", label: "End of Term" },
-  { value: "midterm", label: "Midterm" },
-  { value: "coursework", label: "Coursework" },
-  { value: "practical", label: "Practical" },
+  { value: "assignment_1", label: "Assignment 1" },
+  { value: "assignment_2", label: "Assignment 2" },
+  { value: "test_1",       label: "Test 1" },
+  { value: "test_2",       label: "Test 2" },
+  { value: "practical_1", label: "Practical 1" },
+  { value: "practical_2", label: "Practical 2" },
+  { value: "end_of_term", label: "End of Term Exam" },
+  { value: "midterm",     label: "Midterm" },
+  { value: "coursework",  label: "Coursework" },
+  { value: "practical",   label: "Practical" },
 ] as const;
 
 /** Convert snake_case or raw strings to Title Case for display.

--- a/apps/web/src/modules/marks/MarkCreatePage.tsx
+++ b/apps/web/src/modules/marks/MarkCreatePage.tsx
@@ -18,12 +18,31 @@ import {
 } from "../../lib/ui";
 
 const TERMS = ["Term 1", "Term 2", "Term 3"];
+
+/** UVTAB / UTC Kyema TVET standard assessment types */
 const DEFAULT_ASSESSMENT_TYPES = [
-  { value: "midterm", label: "Midterm" },
-  { value: "end_of_term", label: "End of Term" },
-  { value: "coursework", label: "Coursework" },
-  { value: "practical", label: "Practical" },
+  { value: "assignment_1", label: "Assignment 1" },
+  { value: "assignment_2", label: "Assignment 2" },
+  { value: "test_1",       label: "Test 1" },
+  { value: "test_2",       label: "Test 2" },
+  { value: "practical_1", label: "Practical 1" },
+  { value: "practical_2", label: "Practical 2" },
+  { value: "end_of_term", label: "End of Term Exam" },
+  { value: "midterm",     label: "Midterm" },
+  { value: "coursework",  label: "Coursework" },
+  { value: "practical",   label: "Practical" },
 ];
+
+/** Standard TVET weights (%) — auto-filled when a TVET type is selected */
+const TVET_WEIGHTS: Record<string, number> = {
+  assignment_1: 5,
+  assignment_2: 5,
+  test_1: 10,
+  test_2: 10,
+  practical_1: 25,
+  practical_2: 25,
+  end_of_term: 40,
+};
 
 /** Convert snake_case or raw strings to Title Case for display.
  *  e.g. "end_of_term" → "End of Term", "assignmnt" → "Assignmnt" */
@@ -204,7 +223,13 @@ export function MarkCreatePage() {
               required
               style={selectCss}
               value={form.assessment_type}
-              onChange={(e) => set("assessment_type", e.target.value)}
+              onChange={(e) => {
+                const type = e.target.value;
+                set("assessment_type", type);
+                if (TVET_WEIGHTS[type] !== undefined) {
+                  set("weight", String(TVET_WEIGHTS[type]));
+                }
+              }}
             >
               {assessmentTypes.map((t) => (
                 <option key={t.value} value={t.value}>

--- a/apps/web/src/modules/marks/MarksListPage.tsx
+++ b/apps/web/src/modules/marks/MarksListPage.tsx
@@ -12,6 +12,7 @@ import {
   Badge,
   Pagination,
   PrimaryBtn,
+  SecondaryBtn,
   ErrorBanner,
 } from "../../lib/ui";
 
@@ -22,6 +23,8 @@ const MARK_STATES = [
   "APPROVED",
   "PUBLISHED",
 ];
+
+const CONSOLIDATED_STATES = new Set(["APPROVED", "PUBLISHED"]);
 
 type BadgeColor = "gray" | "blue" | "yellow" | "green" | "cyan";
 const STATE_BADGE: Record<string, BadgeColor> = {
@@ -40,6 +43,7 @@ export function MarksListPage() {
   const intake = params.get("intake") ?? "";
   const term = params.get("term") ?? "";
   const page = Number(params.get("page") ?? "1");
+  const viewMode = params.get("view") ?? "all"; // "all" | "consolidated"
 
   function set(key: string, value: string) {
     setParams((p) => {
@@ -73,16 +77,28 @@ export function MarksListPage() {
       }),
   });
 
-  const isEmpty = !isLoading && !error && (data?.length ?? 0) === 0;
+  // In consolidated mode show only APPROVED / PUBLISHED
+  const displayData = viewMode === "consolidated"
+    ? (data ?? []).filter((s) => CONSOLIDATED_STATES.has(s.current_state ?? ""))
+    : (data ?? []);
+
+  const isEmpty = !isLoading && !error && displayData.length === 0;
 
   return (
     <div>
       <PageHeader
         title="Marks"
         action={
-          <PrimaryBtn onClick={() => navigate("/marks/new")}>
-            + New Submission
-          </PrimaryBtn>
+          <div style={{ display: "flex", gap: 8 }}>
+            <SecondaryBtn
+              onClick={() => set("view", viewMode === "consolidated" ? "all" : "consolidated")}
+            >
+              {viewMode === "consolidated" ? "All Submissions" : "Consolidated (Registrar)"}
+            </SecondaryBtn>
+            <PrimaryBtn onClick={() => navigate("/marks/new")}>
+              + New Submission
+            </PrimaryBtn>
+          </div>
         }
       />
 
@@ -136,15 +152,17 @@ export function MarksListPage() {
       </FilterBar>
 
       <DataTable
-        headers={["Course", "Programme", "Intake / Term", "State", "Created"]}
+        headers={viewMode === "consolidated"
+          ? ["Course", "Programme", "Intake / Term", "Type", "State", "Created"]
+          : ["Course", "Programme", "Intake / Term", "State", "Created"]}
         isLoading={isLoading}
         isEmpty={isEmpty}
         emptyIcon="📊"
-        emptyTitle="No submissions found"
-        emptyDescription='Adjust filters or click "+ New Submission" to add one.'
-        colCount={5}
+        emptyTitle={viewMode === "consolidated" ? "No approved/published submissions" : "No submissions found"}
+        emptyDescription={viewMode === "consolidated" ? "Approved and published marks will appear here." : 'Adjust filters or click "+ New Submission" to add one.'}
+        colCount={viewMode === "consolidated" ? 6 : 5}
       >
-        {data?.map((sub) => (
+        {displayData.map((sub) => (
           <TR key={sub.id} onClick={() => navigate(`/marks/${sub.id}`)}>
             <TD>
               <span style={{ fontWeight: 600, color: "#111827" }}>
@@ -155,6 +173,13 @@ export function MarksListPage() {
             <TD muted>
               {sub.intake} / {sub.term}
             </TD>
+            {viewMode === "consolidated" && (
+              <TD muted>
+                <span style={{ fontFamily: "monospace", fontSize: 12 }}>
+                  {sub.assessment_type ?? "—"}
+                </span>
+              </TD>
+            )}
             <TD>
               <Badge
                 label={sub.current_state ?? "—"}

--- a/apps/web/src/modules/marks/marks.api.ts
+++ b/apps/web/src/modules/marks/marks.api.ts
@@ -7,6 +7,8 @@ export interface Submission {
   programme: string;
   intake: string;
   term: string;
+  assessment_type?: string;
+  weight?: number;
   created_by: string | null;
   created_at: string;
   correction_of_submission_id: string | null;

--- a/db/migrations/20260612000083_marks_assessment_type_text.sql
+++ b/db/migrations/20260612000083_marks_assessment_type_text.sql
@@ -1,0 +1,27 @@
+-- migrate:up
+-- Convert assessment_type from PostgreSQL enum to text so tenants can freely define
+-- TVET assessment types (assignment_1/2, test_1/2, practical_1/2, etc.) without
+-- requiring further migrations.
+
+ALTER TABLE app.mark_submissions
+  ALTER COLUMN assessment_type TYPE text;
+
+-- Drop the old enum type (no longer needed; validation is in application layer)
+DROP TYPE IF EXISTS app.assessment_type CASCADE;
+
+-- migrate:down
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type t JOIN pg_namespace n ON n.oid = t.typnamespace
+                  WHERE t.typname = 'assessment_type' AND n.nspname = 'app') THEN
+    CREATE TYPE app.assessment_type AS ENUM ('midterm','end_of_term','coursework','practical');
+  END IF;
+END $$;
+
+ALTER TABLE app.mark_submissions
+  ALTER COLUMN assessment_type TYPE app.assessment_type
+  USING CASE
+    WHEN assessment_type IN ('midterm','end_of_term','coursework','practical')
+      THEN assessment_type::app.assessment_type
+    ELSE 'end_of_term'::app.assessment_type
+  END;

--- a/db/migrations/20260612000083_marks_assessment_type_text.sql
+++ b/db/migrations/20260612000083_marks_assessment_type_text.sql
@@ -6,6 +6,10 @@
 ALTER TABLE app.mark_submissions
   ALTER COLUMN assessment_type TYPE text;
 
+-- Restore a text DEFAULT so existing code that omits the column still works
+ALTER TABLE app.mark_submissions
+  ALTER COLUMN assessment_type SET DEFAULT 'end_of_term';
+
 -- Drop the old enum type (no longer needed; validation is in application layer)
 DROP TYPE IF EXISTS app.assessment_type CASCADE;
 


### PR DESCRIPTION
## Summary

Closes #229 - TVET marks workflow (UVTAB / UTC Kyema grading scheme)
Closes #225 - 11-step sequential enrolment clearance (UTC Kyema process)

---

## #229 - TVET Marks Workflow

### API
- **Migration** (20260612000083): converts mark_submissions.assessment_type from a fixed PostgreSQL ENUM to 	ext, so tenants can freely define any assessment type string without further schema changes.
- marks.schema.ts: expands ASSESSMENT_TYPES to include TVET types - ssignment_1, ssignment_2, 	est_1, 	est_2, practical_1, practical_2, end_of_term - plus a TVET_WEIGHTS map.

### Web
- **MarkCreatePage**: default assessment type dropdown now shows TVET types; selecting a TVET type **auto-fills the weight field** (assignment: 5%, test: 10%, practical: 25%, end_of_term: 40%).
- **BulkMarkEntryPage**: updated default assessment type list to TVET types.
- **MarksListPage**: added **Consolidated (Registrar)** toggle button - filters view to APPROVED / PUBLISHED submissions only and adds an assessment-type column for the consolidated register view.
- marks.api.ts: Submission interface now includes ssessment_type and weight fields.

---

## #225 - 11-Step Sequential Clearance

### API
- clearance.schema.ts: replaces the 8-dept flat array with ordered CLEARANCE_STEPS (11 steps: Academic Registrar ? Finance ? Warden ? Stores ? **Catering** ? HoD ? Dean ? **Nurse** ? Library ? **ICT Technician** ? Academic Registrar Final). Exports DEPT_STEP, DEPT_LABEL, and type helpers.
- clearance.routes.ts: POST /clearance/sign-off now **enforces sequential order** - every prior step must be SIGNED before the current step can be actioned; returns 422 with a human-readable blocker message (e.g. "Step 2 (Accountant / Finance) must be completed before signing off this step.").

### Web
- **ClearancePage**: replaces the unordered department grid with a **numbered 11-step progress list**:
  - Active step highlighted in blue with Sign / Reject action buttons.
  - Completed steps (? green) show sign-off timestamp.
  - Rejected steps show a Re-sign button.
  - Locked/future steps shown greyed out with ?? indicator.

---

## No breaking changes
- Existing sign-off records are preserved (department is TEXT, no data migration needed).
- Tenants that configured custom assessment types via Admin Studio continue to work (config overrides the default list).