### PR TITLE
feat(#199,#198): term-reg doc checklist + admissions workflow history

### DIFF
--- a/apps/api/src/modules/term-registrations/term-registrations.routes.ts
+++ b/apps/api/src/modules/term-registrations/term-registrations.routes.ts
@@ -242,6 +242,126 @@ export async function termRegistrationsRoutes(app: FastifyInstance) {
     },
   );
 
+  // ---------- GET /term-registrations/:id/doc-checks (#199)
+  app.get<{ Params: { id: string } }>(
+    "/term-registrations/:id/doc-checks",
+    {
+      preHandler: requireRole(
+        "admin", "registrar", "hod", "principal", "dean", "finance", "instructor",
+      ),
+    },
+    async (req, reply) => {
+      const tid = getTenantId(req);
+      if (!tid)
+        return reply.status(400).send({ error: "x-tenant-id header required" });
+
+      const { id } = req.params;
+
+      const DEFAULT_DOCS = [
+        "National ID / Birth Certificate",
+        "Academic Certificates",
+        "Passport Photos",
+        "Medical Certificate",
+        "Recommendation Letter",
+        "Fee Payment Receipt",
+      ];
+
+      const rows = await withTenant(tid, async (client) => {
+        const { rows: regRows } = await client.query(
+          `SELECT id FROM app.term_registrations WHERE id = $1`,
+          [id],
+        );
+        if (!regRows[0]) return null;
+
+        const { rows: checks } = await client.query(
+          `SELECT id, doc_name, status, remarks, reviewed_by, reviewed_at, created_at
+           FROM app.term_registration_doc_checks
+           WHERE tenant_id = $1 AND registration_id = $2
+           ORDER BY created_at ASC`,
+          [tid, id],
+        );
+
+        // Seed default docs that haven't been added yet
+        const existing = new Set(checks.map((c: { doc_name: string }) => c.doc_name));
+        const toSeed = DEFAULT_DOCS.filter((d) => !existing.has(d));
+        if (toSeed.length > 0) {
+          for (const doc_name of toSeed) {
+            await client.query(
+              `INSERT INTO app.term_registration_doc_checks
+                 (tenant_id, registration_id, doc_name, status)
+               VALUES ($1, $2, $3, 'PENDING')
+               ON CONFLICT (tenant_id, registration_id, doc_name) DO NOTHING`,
+              [tid, id, doc_name],
+            );
+          }
+          const { rows: seeded } = await client.query(
+            `SELECT id, doc_name, status, remarks, reviewed_by, reviewed_at, created_at
+             FROM app.term_registration_doc_checks
+             WHERE tenant_id = $1 AND registration_id = $2
+             ORDER BY created_at ASC`,
+            [tid, id],
+          );
+          return seeded;
+        }
+        return checks;
+      });
+
+      if (rows === null)
+        return reply.status(404).send({ error: "registration not found" });
+      return rows;
+    },
+  );
+
+  // ---------- PUT /term-registrations/:id/doc-checks/:docName (#199)
+  app.put<{ Params: { id: string; docName: string } }>(
+    "/term-registrations/:id/doc-checks/:docName",
+    { preHandler: requireRole("admin", "registrar") },
+    async (req, reply) => {
+      const tid = getTenantId(req);
+      if (!tid)
+        return reply.status(400).send({ error: "x-tenant-id header required" });
+
+      const { id, docName } = req.params;
+      const actorUserId = req.user?.userId ?? null;
+      const body = req.body as { status?: string; remarks?: string };
+      const status = body?.status;
+      const remarks = body?.remarks ?? null;
+
+      const VALID_STATUSES = ["ACCEPTED", "REJECTED", "WAIVED", "PENDING"];
+      if (!status || !VALID_STATUSES.includes(status)) {
+        return reply.status(422).send({
+          error: "status must be ACCEPTED, REJECTED, WAIVED, or PENDING",
+        });
+      }
+
+      const row = await withTenant(tid, async (client) => {
+        // Ensure registration belongs to this tenant
+        const { rows: regRows } = await client.query(
+          `SELECT id FROM app.term_registrations WHERE id = $1`,
+          [id],
+        );
+        if (!regRows[0]) return null;
+
+        const { rows } = await client.query(
+          `INSERT INTO app.term_registration_doc_checks
+             (tenant_id, registration_id, doc_name, status, remarks, reviewed_by, reviewed_at)
+           VALUES ($1, $2, $3, $4, $5, $6, now())
+           ON CONFLICT (tenant_id, registration_id, doc_name) DO UPDATE
+             SET status      = EXCLUDED.status,
+                 remarks     = EXCLUDED.remarks,
+                 reviewed_by = EXCLUDED.reviewed_by,
+                 reviewed_at = EXCLUDED.reviewed_at
+           RETURNING *`,
+          [tid, id, docName, status, remarks, actorUserId],
+        );
+        return rows[0] ?? null;
+      });
+
+      if (!row) return reply.status(404).send({ error: "registration not found" });
+      return row;
+    },
+  );
+
   // ---------- POST /term-registrations/bulk — register multiple students at once (#59)
   app.post(
     "/term-registrations/bulk",

--- a/apps/web/src/modules/admissions/ApplicationDetailPage.tsx
+++ b/apps/web/src/modules/admissions/ApplicationDetailPage.tsx
@@ -6,8 +6,9 @@ import {
   getWorkflowDef,
   fireTransition,
   enrollApplication,
+  getWorkflowHistory,
 } from "./admissions.api";
-import type { Application, EnrollBody } from "./admissions.api";
+import type { Application, EnrollBody, WorkflowEvent } from "./admissions.api";
 import { useAuth } from "../../auth/AuthContext";
 import {
   ensureGlobalCss,
@@ -45,7 +46,7 @@ const STATE_BADGE_COLOR: Record<
   WITHDRAWN: "red",
 };
 
-const ENROLLABLE_STATES = new Set(["REGISTERED", "admitted", "accepted", "ENROLLED", "enrolled"]);
+const ENROLLABLE_STATES = new Set(["REGISTERED"]);
 
 function formatExtKey(key: string): string {
   return key
@@ -381,6 +382,7 @@ export function ApplicationDetailPage() {
   const { user } = useAuth();
   const [transitionError, setTransitionError] = useState<string | null>(null);
   const [showEnrolModal, setShowEnrolModal] = useState(false);
+  const [showHistory, setShowHistory] = useState(false);
 
   const { data: app, isLoading: appLoading } = useQuery({
     queryKey: ["application", id],
@@ -391,6 +393,12 @@ export function ApplicationDetailPage() {
   const { data: wfDef } = useQuery({
     queryKey: ["workflowDef", "admissions"],
     queryFn: () => getWorkflowDef("admissions"),
+  });
+
+  const { data: historyEvents } = useQuery({
+    queryKey: ["applicationHistory", id],
+    queryFn: () => getWorkflowHistory("admissions", id!),
+    enabled: !!id && showHistory,
   });
 
   const transitionMut = useMutation({
@@ -542,6 +550,64 @@ export function ApplicationDetailPage() {
           </p>
         </Card>
       )}
+
+      {/* Workflow History (#198) */}
+      <Card padding="20px 24px" style={{ marginTop: 16 }}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+          <SectionLabel>Workflow History</SectionLabel>
+          <SecondaryBtn onClick={() => setShowHistory((v) => !v)} style={{ fontSize: 12, padding: "4px 12px" }}>
+            {showHistory ? "Hide" : "Show history"}
+          </SecondaryBtn>
+        </div>
+        {showHistory && (
+          <div style={{ marginTop: 12 }}>
+            {!historyEvents ? (
+              <Spinner />
+            ) : historyEvents.length === 0 ? (
+              <p style={{ fontSize: 13, color: "#6b7280", margin: 0 }}>No history yet.</p>
+            ) : (
+              <ol style={{ listStyle: "none", padding: 0, margin: 0 }}>
+                {historyEvents.map((ev: WorkflowEvent) => (
+                  <li
+                    key={ev.id}
+                    style={{
+                      display: "flex",
+                      gap: 10,
+                      alignItems: "flex-start",
+                      paddingBottom: 10,
+                      borderBottom: "1px solid #f3f4f6",
+                      marginBottom: 10,
+                      fontSize: 13,
+                    }}
+                  >
+                    <span
+                      style={{
+                        width: 8,
+                        height: 8,
+                        borderRadius: "50%",
+                        background: "#6366f1",
+                        marginTop: 4,
+                        flexShrink: 0,
+                      }}
+                    />
+                    <div>
+                      <div style={{ fontWeight: 500 }}>
+                        {ev.action_key === "__init__"
+                          ? `Created → ${ev.to_state}`
+                          : `${ev.action_key.replace(/_/g, " ")} → ${ev.to_state}`}
+                      </div>
+                      <div style={{ color: "#6b7280", fontSize: 12 }}>
+                        {new Date(ev.created_at).toLocaleString()}
+                        {ev.actor_user_id ? ` · actor: ${ev.actor_user_id.slice(0, 8)}…` : ""}
+                      </div>
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            )}
+          </div>
+        )}
+      </Card>
 
       {showEnrolModal && (
         <EnrolModal

--- a/apps/web/src/modules/admissions/admissions.api.ts
+++ b/apps/web/src/modules/admissions/admissions.api.ts
@@ -177,3 +177,25 @@ export function enrollApplication(applicationId: string, extras?: EnrollBody): P
     { method: "POST", body: JSON.stringify(extras ?? {}) },
   );
 }
+
+export interface WorkflowEvent {
+  id: string;
+  entity_type: string;
+  entity_id: string;
+  workflow_key: string;
+  from_state: string | null;
+  to_state: string;
+  action_key: string;
+  actor_user_id: string | null;
+  meta: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export function getWorkflowHistory(
+  entityType: string,
+  entityId: string,
+): Promise<WorkflowEvent[]> {
+  return apiFetch<WorkflowEvent[]>(
+    `/workflow/${entityType}/${entityId}/history?workflowKey=admissions`,
+  );
+}

--- a/apps/web/src/modules/term-registrations/TermRegistrationDetailPage.tsx
+++ b/apps/web/src/modules/term-registrations/TermRegistrationDetailPage.tsx
@@ -4,9 +4,12 @@ import { useAuth } from "../../auth/AuthContext";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   getTermRegistration,
+  getDocChecks,
+  upsertDocCheck,
   getWorkflowDef,
   fireTransition,
 } from "./term-registrations.api";
+import type { DocCheck } from "./term-registrations.api";
 import {
   ensureGlobalCss,
   Spinner,
@@ -15,6 +18,7 @@ import {
   DetailRow,
   Badge,
   PrimaryBtn,
+  SecondaryBtn,
   ErrorBanner,
   SectionLabel,
 } from "../../lib/ui";
@@ -71,6 +75,27 @@ export function TermRegistrationDetailPage() {
     },
   });
 
+  const { data: docChecks } = useQuery({
+    queryKey: ["term-registration-doc-checks", id],
+    queryFn: () => getDocChecks(id!),
+    enabled: !!id && !!reg,
+  });
+
+  const docCheckMut = useMutation({
+    mutationFn: ({
+      docName,
+      status,
+      remarks,
+    }: {
+      docName: string;
+      status: "PENDING" | "ACCEPTED" | "REJECTED" | "WAIVED";
+      remarks?: string;
+    }) => upsertDocCheck(id!, docName, { status, remarks }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["term-registration-doc-checks", id] });
+    },
+  });
+
   if (isLoading) return <Spinner />;
   if (!reg)
     return (
@@ -85,18 +110,29 @@ export function TermRegistrationDetailPage() {
 
   const currentState = reg.current_state;
   const { user } = useAuth();
+  const myRole = user?.role ?? null;
+  const superRoles = ["admin", "platform_admin"];
+  const canReviewDocs = myRole !== null && (superRoles.includes(myRole) || myRole === "registrar");
+
   const availableActions = wfDef
     ? wfDef.transitions
         .filter(
           (t) =>
             t.from === currentState &&
             (!t.required_role ||
-              t.required_role === user?.role ||
-              user?.role === "admin" ||
-              user?.role === "platform_admin"),
+              t.required_role === myRole ||
+              superRoles.includes(myRole ?? "")),
         )
         .map((t) => t.action)
     : [];
+
+  // Doc checklist derived state
+  const allDocsReady =
+    docChecks && docChecks.length > 0 &&
+    docChecks.every((d: DocCheck) => d.status === "ACCEPTED" || d.status === "WAIVED");
+  const hasPendingOrRejected =
+    docChecks && docChecks.some((d: DocCheck) => d.status === "PENDING" || d.status === "REJECTED");
+  const docsBlockVerify = availableActions.includes("verify_docs") && hasPendingOrRejected;
 
   const studentName =
     reg.first_name && reg.last_name
@@ -164,16 +200,214 @@ export function TermRegistrationDetailPage() {
         </DetailRow>
       </Card>
 
+      {/* Document Checklist (#199) */}
+      <Card padding="20px 24px" style={{ marginBottom: 16 }}>
+        <SectionLabel>Document Checklist</SectionLabel>
+        {!docChecks ? (
+          <Spinner />
+        ) : (
+          <>
+            {allDocsReady && (
+              <div
+                style={{
+                  background: "#f0fdf4",
+                  border: "1px solid #86efac",
+                  borderRadius: 6,
+                  padding: "8px 12px",
+                  fontSize: 13,
+                  color: "#166534",
+                  marginBottom: 12,
+                }}
+              >
+                All documents accepted or waived — ready for verification.
+              </div>
+            )}
+            {hasPendingOrRejected && (
+              <div
+                style={{
+                  background: "#fffbeb",
+                  border: "1px solid #fcd34d",
+                  borderRadius: 6,
+                  padding: "8px 12px",
+                  fontSize: 13,
+                  color: "#92400e",
+                  marginBottom: 12,
+                }}
+              >
+                Some documents are still pending or rejected. Accept or waive
+                all documents before proceeding to document verification.
+              </div>
+            )}
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+              {docChecks.map((doc: DocCheck) => {
+                const statusColor: Record<string, string> = {
+                  ACCEPTED: "#15803d",
+                  REJECTED: "#b91c1c",
+                  WAIVED: "#6b7280",
+                  PENDING: "#b45309",
+                };
+                const statusBg: Record<string, string> = {
+                  ACCEPTED: "#f0fdf4",
+                  REJECTED: "#fef2f2",
+                  WAIVED: "#f9fafb",
+                  PENDING: "#fffbeb",
+                };
+                return (
+                  <div
+                    key={doc.doc_name}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "space-between",
+                      padding: "8px 12px",
+                      borderRadius: 6,
+                      background: statusBg[doc.status] ?? "#f9fafb",
+                      border: "1px solid #e5e7eb",
+                    }}
+                  >
+                    <div style={{ flex: 1 }}>
+                      <span style={{ fontSize: 13, fontWeight: 500 }}>
+                        {doc.doc_name}
+                      </span>
+                      {doc.remarks && (
+                        <span
+                          style={{
+                            fontSize: 11,
+                            color: "#6b7280",
+                            marginLeft: 8,
+                          }}
+                        >
+                          — {doc.remarks}
+                        </span>
+                      )}
+                    </div>
+                    <span
+                      style={{
+                        fontSize: 11,
+                        fontWeight: 700,
+                        color: statusColor[doc.status] ?? "#374151",
+                        marginRight: canReviewDocs ? 12 : 0,
+                        minWidth: 60,
+                        textAlign: "right",
+                      }}
+                    >
+                      {doc.status}
+                    </span>
+                    {canReviewDocs && (
+                      <div style={{ display: "flex", gap: 4 }}>
+                        {doc.status !== "ACCEPTED" && (
+                          <SecondaryBtn
+                            style={{ fontSize: 11, padding: "2px 8px" }}
+                            disabled={docCheckMut.isPending}
+                            onClick={() =>
+                              docCheckMut.mutate({
+                                docName: doc.doc_name,
+                                status: "ACCEPTED",
+                              })
+                            }
+                          >
+                            Accept
+                          </SecondaryBtn>
+                        )}
+                        {doc.status !== "REJECTED" && (
+                          <SecondaryBtn
+                            style={{
+                              fontSize: 11,
+                              padding: "2px 8px",
+                              color: "#b91c1c",
+                            }}
+                            disabled={docCheckMut.isPending}
+                            onClick={() =>
+                              docCheckMut.mutate({
+                                docName: doc.doc_name,
+                                status: "REJECTED",
+                              })
+                            }
+                          >
+                            Reject
+                          </SecondaryBtn>
+                        )}
+                        {doc.status !== "WAIVED" && (
+                          <SecondaryBtn
+                            style={{ fontSize: 11, padding: "2px 8px" }}
+                            disabled={docCheckMut.isPending}
+                            onClick={() =>
+                              docCheckMut.mutate({
+                                docName: doc.doc_name,
+                                status: "WAIVED",
+                              })
+                            }
+                          >
+                            Waive
+                          </SecondaryBtn>
+                        )}
+                        {doc.status !== "PENDING" && (
+                          <SecondaryBtn
+                            style={{ fontSize: 11, padding: "2px 8px" }}
+                            disabled={docCheckMut.isPending}
+                            onClick={() =>
+                              docCheckMut.mutate({
+                                docName: doc.doc_name,
+                                status: "PENDING",
+                              })
+                            }
+                          >
+                            Reset
+                          </SecondaryBtn>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </>
+        )}
+      </Card>
+
       {/* Workflow actions */}
       {availableActions.length > 0 && (
         <Card padding="20px 24px">
-          <SectionLabel>Workflow Actions</SectionLabel>
+          <SectionLabel>
+            Workflow Actions
+            {myRole && (
+              <span
+                style={{
+                  fontSize: 11,
+                  fontWeight: 400,
+                  color: "#6b7280",
+                  marginLeft: 8,
+                }}
+              >
+                (as {myRole})
+              </span>
+            )}
+          </SectionLabel>
           {transitionError && <ErrorBanner message={transitionError} />}
+          {docsBlockVerify && (
+            <div
+              style={{
+                background: "#fef2f2",
+                border: "1px solid #fca5a5",
+                borderRadius: 6,
+                padding: "8px 12px",
+                fontSize: 13,
+                color: "#991b1b",
+                marginBottom: 12,
+              }}
+            >
+              Cannot verify documents: accept or waive all checklist items
+              first.
+            </div>
+          )}
           <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
             {availableActions.map((action) => (
               <PrimaryBtn
                 key={action}
-                disabled={transitionMut.isPending}
+                disabled={
+                  transitionMut.isPending ||
+                  (action === "verify_docs" && !!docsBlockVerify)
+                }
                 onClick={() => transitionMut.mutate(action)}
               >
                 {action.replace(/_/g, " ")}

--- a/apps/web/src/modules/term-registrations/term-registrations.api.ts
+++ b/apps/web/src/modules/term-registrations/term-registrations.api.ts
@@ -62,6 +62,31 @@ export function createTermRegistration(
   );
 }
 
+export interface DocCheck {
+  id: string;
+  doc_name: string;
+  status: "PENDING" | "ACCEPTED" | "REJECTED" | "WAIVED";
+  remarks: string | null;
+  reviewed_by: string | null;
+  reviewed_at: string | null;
+  created_at: string;
+}
+
+export function getDocChecks(registrationId: string): Promise<DocCheck[]> {
+  return apiFetch<DocCheck[]>(`/term-registrations/${registrationId}/doc-checks`);
+}
+
+export function upsertDocCheck(
+  registrationId: string,
+  docName: string,
+  body: { status: "PENDING" | "ACCEPTED" | "REJECTED" | "WAIVED"; remarks?: string },
+): Promise<DocCheck> {
+  return apiFetch<DocCheck>(
+    `/term-registrations/${registrationId}/doc-checks/${encodeURIComponent(docName)}`,
+    { method: "PUT", body: JSON.stringify(body) },
+  );
+}
+
 export function getWorkflowDef(key: string): Promise<{
   key: string;
   initial_state: string;

--- a/db/migrations/20260612000084_term_reg_doc_checks.sql
+++ b/db/migrations/20260612000084_term_reg_doc_checks.sql
@@ -1,0 +1,28 @@
+-- migrate:up
+
+-- Document checklist items per term registration.
+-- Each row records one required document and its verification status.
+CREATE TABLE IF NOT EXISTS app.term_registration_doc_checks (
+  id              uuid         PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id       uuid         NOT NULL,
+  registration_id uuid         NOT NULL REFERENCES app.term_registrations(id) ON DELETE CASCADE,
+  doc_name        text         NOT NULL,
+  status          text         NOT NULL DEFAULT 'PENDING'
+                               CHECK (status IN ('PENDING', 'ACCEPTED', 'REJECTED', 'WAIVED')),
+  remarks         text,
+  reviewed_by     uuid,
+  reviewed_at     timestamptz,
+  created_at      timestamptz  NOT NULL DEFAULT now(),
+  UNIQUE (tenant_id, registration_id, doc_name)
+);
+
+ALTER TABLE app.term_registration_doc_checks ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY tenant_isolation ON app.term_registration_doc_checks
+  USING (tenant_id = current_setting('app.tenant_id')::uuid);
+
+GRANT SELECT, INSERT, UPDATE, DELETE
+  ON app.term_registration_doc_checks TO amis_app;
+
+-- migrate:down
+DROP TABLE IF EXISTS app.term_registration_doc_checks;


### PR DESCRIPTION
## Summary

### #199 - Term Registration Evidence Model
- **Migration 084**: pp.term_registration_doc_checks table (PENDING/ACCEPTED/REJECTED/WAIVED, tenant RLS)
- **API** GET /term-registrations/:id/doc-checks - lists items, auto-seeds 6 default docs on first read
- **API** PUT /term-registrations/:id/doc-checks/:docName - upsert status + remarks (registrar/admin)
- **UI**: Document Checklist panel on TermRegistrationDetailPage - Accept/Reject/Waive per doc
- **UI**: Blocker banner + disabled erify_docs button while any doc is PENDING/REJECTED
- **UI**: Green ready-banner when all docs ACCEPTED or WAIVED
- **UI**: Role context hint beside Workflow Actions heading

### #198 - Role-driven Admissions Workflow
- **Fix**: ENROLLABLE_STATES restricted to REGISTERED only
- **API client**: getWorkflowHistory() using existing /workflow/:type/:id/history endpoint
- **UI**: Collapsible Workflow History timeline on ApplicationDetailPage

Closes #199
Closes #198