### PR TITLE
hotfix: pin @fastify/rate-limit back to ^9.1.0 (v11 incompatible with Fastify v4)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,7 +14,7 @@
     "@fastify/cors": "^9.0.1",
     "@fastify/helmet": "11",
     "@fastify/multipart": "^7.7.3",
-    "@fastify/rate-limit": "^11.0.0",
+    "@fastify/rate-limit": "^9.1.0",
     "@fastify/static": "^6.12.0",
     "bcryptjs": "^3.0.3",
     "bullmq": "^5.78.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
         specifier: ^7.7.3
         version: 7.7.3
       '@fastify/rate-limit':
-        specifier: ^11.0.0
-        version: 11.0.0
+        specifier: ^9.1.0
+        version: 9.1.0
       '@fastify/static':
         specifier: ^6.12.0
         version: 6.12.0
@@ -836,8 +836,8 @@ packages:
   '@fastify/multipart@7.7.3':
     resolution: {integrity: sha512-MG4Gd9FNEXc8qx0OgqoXM10EGO/dN/0iVQ8SrpFMU3d6F6KUfcqD2ZyoQhkm9LWrbiMgdHv5a43x78lASdn5GA==}
 
-  '@fastify/rate-limit@11.0.0':
-    resolution: {integrity: sha512-kCs+G59SitZw9TL/ekFe+MrzXk20dEp6zPAM8WEZjFl5Ubvv5ksTbEXYr4jGlBwWAKn78q+NFsj5CN75zXLjaw==}
+  '@fastify/rate-limit@9.1.0':
+    resolution: {integrity: sha512-h5dZWCkuZXN0PxwqaFQLxeln8/LNwQwH9popywmDCFdKfgpi4b/HoMH1lluy6P+30CG9yzzpSpwTCIPNB9T1JA==}
 
   '@fastify/send@2.1.0':
     resolution: {integrity: sha512-yNYiY6sDkexoJR0D8IDy3aRP3+L4wdqCpvx5WP+VtEU58sn7USmKynBzDQex5X42Zzvw2gNzzYgP90UfWShLFA==}
@@ -1648,9 +1648,6 @@ packages:
 
   fastify-plugin@4.5.1:
     resolution: {integrity: sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ==}
-
-  fastify-plugin@5.1.0:
-    resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
 
   fastify@4.29.1:
     resolution: {integrity: sha512-m2kMNHIG92tSNWv+Z3UeTR9AWLLuo7KctC7mlFPtMEVrfjIhmQhkQnT9v15qA/BfVq3vvj134Y0jl9SBje3jXQ==}
@@ -3746,10 +3743,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fastify/rate-limit@11.0.0':
+  '@fastify/rate-limit@9.1.0':
     dependencies:
       '@lukeed/ms': 2.0.2
-      fastify-plugin: 5.1.0
+      fastify-plugin: 4.5.1
       toad-cache: 3.7.1
 
   '@fastify/send@2.1.0':
@@ -4537,8 +4534,6 @@ snapshots:
   fast-uri@3.1.2: {}
 
   fastify-plugin@4.5.1: {}
-
-  fastify-plugin@5.1.0: {}
 
   fastify@4.29.1:
     dependencies:


### PR DESCRIPTION
## Problem

PR #265 (Dependabot) bumped `@fastify/rate-limit` from `9.1.0` → `11.0.0`. This is a **breaking change** — `@fastify/rate-limit` v10+ requires **Fastify v5**, but the app currently runs on **Fastify v4** (`^4.28.0`).

If this is left in place, the API will **fail to start** on next Docker rebuild.

## Fix

Pins `@fastify/rate-limit` back to `^9.1.0` and regenerates `pnpm-lock.yaml`.

## Notes

- To actually upgrade to `@fastify/rate-limit` v11, the entire Fastify core must first be upgraded to v5 (a significant migration).
- Dependabot should be configured to not auto-propose major version bumps for `@fastify/*` plugins until Fastify v5 is adopted.
- After merging this PR, comment `@dependabot rebase` on PR #262 (vite 8.0.16) to fix its pnpm-lock.yaml conflict.