### PR TITLE
fix: POST /feedback is public — no auth required

### DIFF
--- a/apps/api/src/middleware/requireAuth.ts
+++ b/apps/api/src/middleware/requireAuth.ts
@@ -26,6 +26,7 @@ const PUBLIC_PATHS = new Set([
   "GET /health",
   "POST /onboarding", // VTI self-registration is public
   "GET /tenants/verify-email", // contact email verification link (public)
+  "POST /feedback", // UAT feedback form is public (no login required)
 ]);
 
 /** Route prefixes that never require authentication. */


### PR DESCRIPTION
## Problem

`POST /feedback` (the UAT feedback form endpoint) was blocked by the global `requireAuth` hook with a 401, even though the form is intentionally public — no login required.

## Fix

One-line change: adds `"POST /feedback"` to the `PUBLIC_PATHS` set in `requireAuth.ts`, using the same pattern as `POST /onboarding` and `POST /auth/login`.

## After merging

Rebuild and restart only the API container on staging:
```bash
docker compose --env-file .env.staging -f docker-compose.staging.yml --project-name amis-staging up -d --build api
```