### PR TITLE
fix: feedback form requires login — use apiFetch, remove public bypass

### DIFF
--- a/apps/api/src/middleware/requireAuth.ts
+++ b/apps/api/src/middleware/requireAuth.ts
@@ -26,7 +26,6 @@ const PUBLIC_PATHS = new Set([
   "GET /health",
   "POST /onboarding", // VTI self-registration is public
   "GET /tenants/verify-email", // contact email verification link (public)
-  "POST /feedback", // UAT feedback form is public (no login required)
 ]);
 
 /** Route prefixes that never require authentication. */

--- a/apps/web/src/modules/public/UATFeedbackPage.tsx
+++ b/apps/web/src/modules/public/UATFeedbackPage.tsx
@@ -4,6 +4,7 @@
  * Route: /uat-feedback  (no auth required)
  */
 import { useState } from "react";
+import { apiFetch } from "../../lib/apiFetch";
 import { ensureGlobalCss, C, inputCss } from "../../lib/ui";
 
 // ---------------------------------------------------------------------------
@@ -195,18 +196,11 @@ export function UATFeedbackPage() {
 
     try {
       const roleDisplay = form.role === "Other" ? form.otherRole || "Other" : form.role;
-      const API_URL = import.meta.env.VITE_API_URL ?? "http://localhost:3000";
 
-      const res = await fetch(`${API_URL}/feedback`, {
+      await apiFetch<void>("/feedback", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ ...form, role: roleDisplay }),
       });
-
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error((data as { message?: string }).message ?? `Server error ${res.status}`);
-      }
 
       setSubmitted(true);
     } catch (e) {


### PR DESCRIPTION
## What

Two corrections to the UAT feedback form:

1. **`requireAuth.ts`** — removes `\"POST /feedback\"` from `PUBLIC_PATHS`. The endpoint requires a logged-in user (UAT testers have accounts).

2. **`UATFeedbackPage.tsx`** — replaces raw `fetch()` with `apiFetch()`, which automatically attaches `Authorization: Bearer <token>` from the user's session — same pattern used by every other page in the app.

## Why

The previous PR (#270) was merged before the corrective commit landed, so main ended up with the public bypass but without the `apiFetch` change, leaving the form broken for authenticated users.

## After merging

Rebuild both containers:
```bash
docker compose --env-file .env.staging -f docker-compose.staging.yml --project-name amis-staging up -d --build api web
```