### PR TITLE
fix: wrap /uat-feedback in ProtectedRoute (redirect unauthenticated users to login)

### DIFF
--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -138,7 +138,11 @@ export const router = createBrowserRouter([
   },
   {
     path: "/uat-feedback",
-    element: <UATFeedbackPage />,
+    element: (
+      <ProtectedRoute>
+        <UATFeedbackPage />
+      </ProtectedRoute>
+    ),
   },
   {
     path: "/setup",


### PR DESCRIPTION
Wraps `/uat-feedback` in `<ProtectedRoute>` so unauthenticated visitors are redirected to `/login?redirect=/uat-feedback` immediately on page load, instead of being able to fill out the entire form and only hitting a 401 on submit.\n\nOne-line change to `routes.tsx`. After merging, rebuild the **web** container only:\n```bash\ndocker compose --env-file .env.staging -f docker-compose.staging.yml --project-name amis-staging build --no-cache web\ndocker compose --env-file .env.staging -f docker-compose.staging.yml --project-name amis-staging up -d web\n```