### PR TITLE
fix: ProtectedRoute redirects to login with ?redirect= (returns user after login)

### DIFF
--- a/apps/web/src/auth/ProtectedRoute.tsx
+++ b/apps/web/src/auth/ProtectedRoute.tsx
@@ -1,9 +1,10 @@
 import { type ReactNode } from "react";
-import { Navigate } from "react-router-dom";
+import { Navigate, useLocation } from "react-router-dom";
 import { useAuth } from "./AuthContext";
 
 export function ProtectedRoute({ children }: { children: ReactNode }) {
   const { isAuthenticated, isLoading } = useAuth();
+  const location = useLocation();
 
   if (isLoading) {
     return (
@@ -23,7 +24,8 @@ export function ProtectedRoute({ children }: { children: ReactNode }) {
   }
 
   if (!isAuthenticated) {
-    return <Navigate to="/login" replace />;
+    const redirect = location.pathname + location.search;
+    return <Navigate to={`/login?redirect=${encodeURIComponent(redirect)}`} replace />;
   }
 
   return <>{children}</>;


### PR DESCRIPTION
## What

Two fixes bundled together:

1. **`routes.tsx`** — wraps `/uat-feedback` in `<ProtectedRoute>` so unauthenticated users are redirected to login **immediately on page load**, not after filling the form and hitting submit.

2. **`ProtectedRoute.tsx`** — passes `?redirect=<current path>` to the login redirect so after logging in, users are automatically returned to the page they were trying to visit (e.g. back to `/uat-feedback`). This improvement applies to all protected routes in the app.

## After merging

```bash
cd /opt/amis
git pull origin main
docker compose --env-file .env.staging -f docker-compose.staging.yml --project-name amis-staging build --no-cache web
docker compose --env-file .env.staging -f docker-compose.staging.yml --project-name amis-staging up -d web
```