### PR TITLE
fix: address UAT workflow issues

### DIFF
--- a/apps/api/src/modules/clearance/clearance.routes.ts
+++ b/apps/api/src/modules/clearance/clearance.routes.ts
@@ -41,8 +41,12 @@ async function computeEligibility(
   const { rows: stuRows } = await client.query<{
     id: string;
     programme_id: string | null;
+    programme: string | null;
+    programme_code: string | null;
+    sponsorship_type: string | null;
   }>(
-    `SELECT id, programme_id FROM app.students WHERE id = $1`,
+    `SELECT id, programme_id, programme, programme_code, sponsorship_type
+     FROM app.students WHERE id = $1`,
     [studentId],
   );
   if (!stuRows[0]) return { notFound: true };
@@ -78,10 +82,29 @@ async function computeEligibility(
   let feesPaid = 0;
   if (student.programme_id) {
     const { rows: feeRows } = await client.query<{ total: string }>(
-      `SELECT COALESCE(SUM(amount), 0) AS total
-       FROM app.fee_structures
-       WHERE programme_id = $1 AND academic_year_id = $2 AND is_active = true`,
-      [student.programme_id, term.academic_year_id],
+      `SELECT COALESCE(SUM(fs.amount), 0) AS total
+       FROM app.fee_structures fs
+       JOIN app.programmes p ON p.id = fs.programme_id
+       LEFT JOIN app.terms fee_term ON fee_term.id = fs.term_id
+       WHERE fs.academic_year_id = $1
+         AND fs.is_active = true
+         AND (fs.term_id IS NULL OR fee_term.id = $2)
+         AND fs.student_category = ANY(
+           CASE
+             WHEN LOWER($3) LIKE '%boarding%' OR LOWER($3) LIKE '%boarder%'
+               THEN ARRAY['all', 'boarding']::text[]
+             WHEN LOWER($3) LIKE '%day%'
+               OR (NULLIF(TRIM($3), '') IS NOT NULL)
+               THEN ARRAY['all', 'day']::text[]
+             ELSE ARRAY['all']::text[]
+           END
+         )
+         AND (
+           fs.programme_id = $4::uuid
+           OR LOWER(p.code) = LOWER(COALESCE($5, ''))
+           OR LOWER(p.title) = LOWER(COALESCE($6, ''))
+         )`,
+      [term.academic_year_id, termId, student.sponsorship_type ?? "", student.programme_id, student.programme_code, student.programme],
     );
     feesDue = parseFloat(feeRows[0]?.total ?? "0");
 

--- a/apps/api/src/modules/fees/fees.routes.ts
+++ b/apps/api/src/modules/fees/fees.routes.ts
@@ -711,17 +711,52 @@ export async function feesRoutes(app: FastifyInstance) {
           cfgRows[0]?.payload?.fees?.defaultTotalDue ?? 0;
 
         const { rows } = await client.query(
-          `SELECT s.id, s.first_name, s.last_name, s.admission_number, s.programme,
-                  COALESCE(p.total_paid, 0) AS total_paid,
-                  ($1 - COALESCE(p.total_paid, 0)) AS balance
-           FROM app.students s
-           LEFT JOIN (
-             SELECT student_id, SUM(amount) AS total_paid
-             FROM app.payments
-             GROUP BY student_id
-           ) p ON p.student_id = s.id
-           WHERE s.is_active = true
-             AND COALESCE(p.total_paid, 0) < $1
+          `WITH student_cats AS (
+             SELECT
+               s.id,
+               s.first_name,
+               s.last_name,
+               s.admission_number,
+               s.programme,
+               s.programme_id,
+               s.programme_code,
+               CASE
+                 WHEN LOWER(s.sponsorship_type) LIKE '%boarding%'
+                   OR LOWER(s.sponsorship_type) LIKE '%boarder%' THEN 'boarding'
+                 WHEN LOWER(s.sponsorship_type) LIKE '%day%'
+                   OR (s.sponsorship_type IS NOT NULL AND TRIM(s.sponsorship_type) != '') THEN 'day'
+                 ELSE 'all'
+               END AS category
+             FROM app.students s
+             WHERE s.is_active = true
+           ), student_balances AS (
+             SELECT
+               sc.*,
+               COALESCE((
+                 SELECT SUM(fs.amount)
+                 FROM app.fee_structures fs
+                 JOIN app.programmes p ON p.id = fs.programme_id
+                 JOIN app.academic_years ay ON ay.id = fs.academic_year_id AND ay.is_current = true
+                 LEFT JOIN app.terms t ON t.id = fs.term_id
+                 WHERE fs.is_active = true
+                   AND (fs.term_id IS NULL OR t.is_current = true)
+                   AND fs.student_category = ANY(ARRAY['all', sc.category])
+                   AND (
+                     fs.programme_id = sc.programme_id
+                     OR LOWER(p.code) = LOWER(COALESCE(sc.programme_code, ''))
+                     OR LOWER(p.title) = LOWER(COALESCE(sc.programme, ''))
+                   )
+               ), $1) AS total_due,
+               COALESCE((
+                 SELECT SUM(amount) FROM app.payments WHERE student_id = sc.id
+               ), 0) AS total_paid
+             FROM student_cats sc
+           )
+           SELECT id, first_name, last_name, admission_number, programme,
+                  total_paid,
+                  (total_due - total_paid) AS balance
+           FROM student_balances
+           WHERE total_paid < total_due
            ORDER BY balance DESC`,
           [defaultTotalDue],
         );
@@ -757,8 +792,6 @@ export async function feesRoutes(app: FastifyInstance) {
         );
         const threshold: number =
           cfgRows[0]?.payload?.fees?.clearanceThreshold ?? 100;
-        const totalDue: number =
-          cfgRows[0]?.payload?.fees?.defaultTotalDue ?? 0;
 
         // Verify student exists
         const { rows: stuRows } = await client.query(
@@ -767,23 +800,25 @@ export async function feesRoutes(app: FastifyInstance) {
         );
         if (stuRows.length === 0) return { notFound: true } as const;
 
-        // Sum payments
+        const due = await calculateStudentTotalDue(client, tid, studentId);
+        if ("notFound" in due) return due;
+
         const { rows: payRows } = await client.query(
           `SELECT COALESCE(SUM(amount), 0) AS total_paid FROM app.payments WHERE student_id = $1`,
           [studentId],
         );
         const totalPaid = Number(payRows[0].total_paid);
-        const requiredAmount = (threshold / 100) * totalDue;
+        const requiredAmount = (threshold / 100) * due.totalDue;
         const cleared = totalPaid >= requiredAmount;
 
         return {
           student: stuRows[0],
-          totalDue,
+          totalDue: due.totalDue,
           totalPaid,
           threshold,
           requiredAmount,
           cleared,
-          balance: totalDue - totalPaid,
+          balance: due.totalDue - totalPaid,
         };
       });
 

--- a/apps/web/src/modules/admissions/ApplicationCreatePage.tsx
+++ b/apps/web/src/modules/admissions/ApplicationCreatePage.tsx
@@ -102,7 +102,7 @@ export function ApplicationCreatePage() {
         first_name: form.first_name,
         last_name: form.last_name,
         programme: form.programme,
-        intake: form.intake,
+        intake: form.intake || defaultIntake,
         dob: form.dob || undefined,
         gender: form.gender || undefined,
         email: form.email || undefined,

--- a/apps/web/src/modules/attendance/AttendancePage.tsx
+++ b/apps/web/src/modules/attendance/AttendancePage.tsx
@@ -10,7 +10,6 @@ import {
   type AttendanceStatus,
   type BatchAttendanceItem,
 } from "./attendance.api";
-import { useConfig } from "../../app/ConfigProvider";
 import { listAcademicYears } from "../academic-calendar/academic-calendar.api";
 import { listCourses } from "../courses/courses.api";
 import { listProgrammes } from "../programmes/programmes.api";
@@ -33,8 +32,6 @@ type ViewMode = "sheet" | "summary";
 export function AttendancePage() {
   ensureGlobalCss();
   const qc = useQueryClient();
-  const { programmes } = useConfig() as { programmes?: string[] };
-
   // All useState hooks must come first (before any queries or derived values)
   const [filters, setFilters] = useState({
     programme: "",
@@ -239,7 +236,7 @@ export function AttendancePage() {
             />
           </Field>
           <Field label="Programme">
-            {programmes && programmes.length > 0 ? (
+            {programmesList.length > 0 ? (
               <select
                 style={selectCss}
                 value={filters.programme}
@@ -248,9 +245,9 @@ export function AttendancePage() {
                 }
               >
                 <option value="">All programmes</option>
-                {programmes.map((p) => (
-                  <option key={p} value={p}>
-                    {p}
+                {programmesList.map((p) => (
+                  <option key={p.id} value={p.code}>
+                    {p.code} — {p.title}
                   </option>
                 ))}
               </select>

--- a/apps/web/src/modules/field-placements/FieldPlacementDetailPage.tsx
+++ b/apps/web/src/modules/field-placements/FieldPlacementDetailPage.tsx
@@ -69,8 +69,8 @@ export function FieldPlacementDetailPage() {
       host_organisation: data.host_organisation,
       supervisor: data.supervisor ?? "",
       placement_type: data.placement_type,
-      start_date: data.start_date ?? "",
-      end_date: data.end_date ?? "",
+      start_date: data.start_date?.slice(0, 10) ?? "",
+      end_date: data.end_date?.slice(0, 10) ?? "",
       status: data.status,
       notes: data.notes ?? "",
     });

--- a/apps/web/src/modules/industrial-training/IndustrialTrainingDetailPage.tsx
+++ b/apps/web/src/modules/industrial-training/IndustrialTrainingDetailPage.tsx
@@ -67,11 +67,11 @@ export function IndustrialTrainingDetailPage() {
   function startEdit() {
     if (!data) return;
     setForm({
-      company: data.company,
+      company: data.company ?? "",
       supervisor: data.supervisor ?? "",
       department: data.department ?? "",
-      start_date: data.start_date ?? "",
-      end_date: data.end_date ?? "",
+      start_date: data.start_date?.slice(0, 10) ?? "",
+      end_date: data.end_date?.slice(0, 10) ?? "",
       status: data.status,
       notes: data.notes ?? "",
     });
@@ -114,7 +114,7 @@ export function IndustrialTrainingDetailPage() {
   return (
     <div>
       <PageHeader
-        title={data.company}
+        title={data.company || "Industrial Training"}
         back={{ label: "Industrial Training", to: "/industrial-training" }}
         action={
           <Badge label={data.status} color={STATUS_BADGE[data.status]} />

--- a/apps/web/src/modules/marks/MarkDetailPage.tsx
+++ b/apps/web/src/modules/marks/MarkDetailPage.tsx
@@ -310,6 +310,8 @@ export function MarkDetailPage() {
       setEntriesSuccess(true);
       setDraftRows([mkRow()]);
       qc.invalidateQueries({ queryKey: ["submission", id] });
+      qc.invalidateQueries({ queryKey: ["submissions"] });
+      qc.invalidateQueries({ queryKey: ["marks-analysis"] });
     },
     onError: (err) => {
       setEntriesSuccess(false);

--- a/apps/web/src/modules/students/StudentDetailPage.tsx
+++ b/apps/web/src/modules/students/StudentDetailPage.tsx
@@ -13,6 +13,7 @@ import { getStudent,
   type UpdateStudentBody,
   type DeactivateStudentBody,
 } from "./students.api";
+import { graduateStudent } from "../alumni/alumni.api";
 import { StudentDocumentsSection } from "./StudentDocumentsSection";
 import { listStudentProjects, createStudentProject, type ProjectStatus } from "../student-projects/student-projects.api";
 import { listProgrammes } from "../programmes/programmes.api";
@@ -70,6 +71,9 @@ export function StudentDetailPage() {
   });
 
   const [showDeactivateModal, setShowDeactivateModal] = useState(false);
+  const [showGraduateModal, setShowGraduateModal] = useState(false);
+  const [graduationDate, setGraduationDate] = useState(new Date().toISOString().slice(0, 10));
+  const [graduationNotes, setGraduationNotes] = useState("");
   const [dropoutForm, setDropoutForm] = useState<DeactivateStudentBody>({
     dropout_reason: "",
     dropout_date: "",
@@ -114,6 +118,19 @@ export function StudentDetailPage() {
     onSuccess: (updated) => {
       qc.setQueryData(["students", id], updated);
       qc.invalidateQueries({ queryKey: ["students"] });
+    },
+  });
+
+  const graduateMutation = useMutation({
+    mutationFn: () =>
+      graduateStudent(id!, {
+        graduation_date: graduationDate,
+        graduation_notes: graduationNotes || undefined,
+      }),
+    onSuccess: () => {
+      setShowGraduateModal(false);
+      qc.invalidateQueries({ queryKey: ["students"] });
+      navigate("/alumni");
     },
   });
 
@@ -245,6 +262,9 @@ export function StudentDetailPage() {
                 color={student.is_active ? "green" : "gray"}
               />
               <PrimaryBtn onClick={startEdit}>Edit</PrimaryBtn>
+              <SecondaryBtn onClick={() => setShowGraduateModal(true)}>
+                Graduate
+              </SecondaryBtn>
               {student.is_active ? (
                 <SecondaryBtn
                   onClick={() => {
@@ -935,6 +955,51 @@ export function StudentDetailPage() {
             </div>
           </form>
         </Card>
+      )}
+
+      {showGraduateModal && (
+        <div
+          style={{
+            position: "fixed", inset: 0, background: "rgba(0,0,0,0.4)",
+            display: "flex", alignItems: "center", justifyContent: "center", zIndex: 999,
+          }}
+          onClick={(e) => { if (e.target === e.currentTarget) setShowGraduateModal(false); }}
+        >
+          <Card padding="28px" style={{ width: 440, maxWidth: "95vw" }}>
+            <div style={{ fontSize: 16, fontWeight: 700, marginBottom: 4 }}>Graduate Student</div>
+            <div style={{ fontSize: 13, color: C.gray500, marginBottom: 20 }}>
+              This will add the student to Alumni and mark the student inactive.
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+              <Field label="Graduation date" required>
+                <input
+                  type="date"
+                  style={inputCss}
+                  value={graduationDate}
+                  onChange={(e) => setGraduationDate(e.target.value)}
+                />
+              </Field>
+              <Field label="Graduation notes">
+                <textarea
+                  style={{ ...inputCss, height: 72, resize: "vertical" }}
+                  value={graduationNotes}
+                  onChange={(e) => setGraduationNotes(e.target.value)}
+                  placeholder="Award, qualification, or other graduation details"
+                />
+              </Field>
+              {graduateMutation.isError && <ErrorBanner message="Graduation failed. Please try again." />}
+              <div style={{ display: "flex", gap: 8 }}>
+                <PrimaryBtn
+                  onClick={() => graduateMutation.mutate()}
+                  disabled={!graduationDate || graduateMutation.isPending}
+                >
+                  {graduateMutation.isPending ? "Graduating…" : "Confirm Graduation"}
+                </PrimaryBtn>
+                <SecondaryBtn onClick={() => setShowGraduateModal(false)}>Cancel</SecondaryBtn>
+              </div>
+            </div>
+          </Card>
+        </div>
       )}
 
       {/* Deactivate / Dropout modal (SR-F-003) */}


### PR DESCRIPTION
## Summary
- normalize Industrial Training and Field Placement edit dates and guard missing company data
- fix admissions intake fallback submission
- make fees defaulters and clearance category-aware
- refresh marks-related queries after saving entries
- populate Attendance programmes from the live API list
- expose student graduation from Student Detail

## Validation
- API and web typechecks pass
- focused API regression suites pass
- fees: 43 tests
- students, clearance, and alumni: 52 tests

Addresses UAT issues #279, #280, #281, #282, #283, #285, #286, #288, and #289.