### PR TITLE
fix: discard dead pg connections instead of returning them to the pool

### DIFF
--- a/apps/api/src/db/pool.ts
+++ b/apps/api/src/db/pool.ts
@@ -64,6 +64,38 @@ function getPool(): pg.Pool {
   return _pool;
 }
 
+const CONNECTION_ERROR_CODES = new Set([
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "EPIPE",
+  "ETIMEDOUT",
+  "57P01", // admin_shutdown
+  "57P02", // crash_shutdown
+  "57P03", // cannot_connect_now
+  "08000", // connection_exception
+  "08003", // connection_does_not_exist
+  "08006", // connection_failure
+]);
+
+/**
+ * True when an error means the underlying socket died (long idle period with
+ * a NAT/firewall/conntrack drop, server restart, etc.) rather than a routine
+ * SQL error such as a constraint violation. A client that hit this kind of
+ * error must be discarded from the pool — reusing it will fail forever,
+ * which is why "database unreachable" used to persist until a full
+ * container restart instead of self-healing on the next request.
+ */
+export function isConnectionError(err: unknown): boolean {
+  const code = (err as { code?: string } | undefined)?.code;
+  const message = err instanceof Error ? err.message : String(err ?? "");
+  return (
+    (code != null && CONNECTION_ERROR_CODES.has(code)) ||
+    /connection terminated|terminating connection|server closed the connection/i.test(
+      message,
+    )
+  );
+}
+
 export const pool: pg.Pool = new Proxy({} as pg.Pool, {
   get(_t, prop) {
     return (getPool() as unknown as Record<string | symbol, unknown>)[prop];

--- a/apps/api/src/db/tenant.ts
+++ b/apps/api/src/db/tenant.ts
@@ -1,5 +1,5 @@
 import type { PoolClient, QueryResult } from "pg";
-import { pool } from "./pool.js";
+import { pool, isConnectionError } from "./pool.js";
 
 /**
  * Run a callback inside a transaction with tenant isolation enforced.
@@ -10,6 +10,7 @@ export async function withTenant<T>(
   fn: (client: PoolClient) => Promise<T>,
 ): Promise<T> {
   const client = await pool.connect();
+  let connectionDied = false;
   try {
     await client.query("BEGIN");
     await client.query("SELECT set_config('app.tenant_id', $1, true)", [
@@ -22,10 +23,14 @@ export async function withTenant<T>(
     await client.query("COMMIT");
     return result;
   } catch (err) {
-    await client.query("ROLLBACK");
+    connectionDied = isConnectionError(err);
+    // Rolling back on a dead socket would just throw again — skip it.
+    if (!connectionDied) await client.query("ROLLBACK").catch(() => {});
     throw err;
   } finally {
-    client.release();
+    // Discard the client on a connection-level error instead of returning a
+    // dead connection to the pool, where every future request would reuse it.
+    client.release(connectionDied);
   }
 }
 

--- a/apps/api/src/modules/onboarding/onboarding.routes.ts
+++ b/apps/api/src/modules/onboarding/onboarding.routes.ts
@@ -12,7 +12,7 @@
  */
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
-import { pool, superPool } from "../../db/pool.js";
+import { pool, superPool, isConnectionError } from "../../db/pool.js";
 import { hashPasswordAsync } from "../../lib/password.js";
 import { signToken } from "../../lib/jwt.js";
 import { requireRole } from "../../middleware/requireRole.js";
@@ -118,6 +118,7 @@ export async function onboardingRoutes(app: FastifyInstance) {
     } = parsed.data;
 
     const client = await pool.connect();
+    let connectionDied = false;
     try {
       await client.query("BEGIN");
 
@@ -190,7 +191,8 @@ export async function onboardingRoutes(app: FastifyInstance) {
         refreshToken,
       });
     } catch (err: unknown) {
-      await client.query("ROLLBACK");
+      connectionDied = isConnectionError(err);
+      if (!connectionDied) await client.query("ROLLBACK").catch(() => {});
       const pgErr = err as { code?: string };
       if (pgErr.code === "23505") {
         return reply.status(409).send({
@@ -200,7 +202,7 @@ export async function onboardingRoutes(app: FastifyInstance) {
       }
       throw err;
     } finally {
-      client.release();
+      client.release(connectionDied);
     }
   });
 
@@ -232,6 +234,7 @@ export async function onboardingRoutes(app: FastifyInstance) {
       // blocks INSERT when app.tenant_id is not set. Provisioning is a
       // platform-admin operation so the superuser connection is correct.
       const client = await superPool.connect();
+      let connectionDied = false;
       try {
         await client.query("BEGIN");
 
@@ -315,7 +318,8 @@ export async function onboardingRoutes(app: FastifyInstance) {
           loginUrl: `/login?tenantSlug=${slug}`,
         });
       } catch (err: unknown) {
-        await client.query("ROLLBACK");
+        connectionDied = isConnectionError(err);
+        if (!connectionDied) await client.query("ROLLBACK").catch(() => {});
         const pgErr = err as { code?: string };
         if (pgErr.code === "23505") {
           return reply.status(409).send({
@@ -325,7 +329,7 @@ export async function onboardingRoutes(app: FastifyInstance) {
         }
         throw err;
       } finally {
-        client.release();
+        client.release(connectionDied);
       }
     },
   );

--- a/apps/api/src/modules/sync/sync.routes.ts
+++ b/apps/api/src/modules/sync/sync.routes.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import type { PoolClient } from "pg";
 import { z } from "zod";
-import { superPool } from "../../db/pool.js";
+import { superPool, isConnectionError } from "../../db/pool.js";
 import { getOutboxQueue } from "../../lib/queue.js";
 import { getTenantId } from "../../lib/tenantId.js";
 
@@ -227,6 +227,7 @@ export async function syncRoutes(app: FastifyInstance) {
     const conflicts: ConflictResult[] = [];
 
     const client = await superPool.connect();
+    let connectionDied = false;
     try {
       await client.query("BEGIN");
       await client.query("SELECT set_config('app.tenant_id', $1, true)", [
@@ -283,10 +284,11 @@ export async function syncRoutes(app: FastifyInstance) {
 
       await client.query("COMMIT");
     } catch (err) {
-      await client.query("ROLLBACK");
+      connectionDied = isConnectionError(err);
+      if (!connectionDied) await client.query("ROLLBACK").catch(() => {});
       throw err;
     } finally {
-      client.release();
+      client.release(connectionDied);
     }
 
     return reply.status(200).send({

--- a/apps/api/src/modules/tenants/tenants.routes.ts
+++ b/apps/api/src/modules/tenants/tenants.routes.ts
@@ -13,7 +13,7 @@
 import type { FastifyInstance } from "fastify";
 import { createHash, randomBytes } from "crypto";
 import { z } from "zod";
-import { pool, superPool } from "../../db/pool.js";
+import { pool, superPool, isConnectionError } from "../../db/pool.js";
 import { requireRole } from "../../middleware/requireRole.js";
 import { sendMail, buildTenantVerificationEmail } from "../../lib/email.js";
 
@@ -447,6 +447,7 @@ export async function tenantsRoutes(app: FastifyInstance) {
       // We temporarily disable it (requires superuser) within a transaction so the
       // CASCADE can remove workflow_events rows belonging to this tenant.
       const client = await superPool.connect();
+      let connectionDied = false;
       let result: { rows: { id: string }[] };
       try {
         await client.query("BEGIN");
@@ -458,12 +459,15 @@ export async function tenantsRoutes(app: FastifyInstance) {
         await client.query("ALTER TABLE app.workflow_events ENABLE TRIGGER ALL");
         await client.query("COMMIT");
       } catch (err) {
-        await client.query("ROLLBACK");
-        // Best-effort re-enable in case the DISABLE succeeded but DELETE failed
-        await client.query("ALTER TABLE app.workflow_events ENABLE TRIGGER ALL").catch(() => {});
+        connectionDied = isConnectionError(err);
+        if (!connectionDied) {
+          await client.query("ROLLBACK").catch(() => {});
+          // Best-effort re-enable in case the DISABLE succeeded but DELETE failed
+          await client.query("ALTER TABLE app.workflow_events ENABLE TRIGGER ALL").catch(() => {});
+        }
         throw err;
       } finally {
-        client.release();
+        client.release(connectionDied);
       }
 
       if (result.rows.length === 0) {


### PR DESCRIPTION
## Problem

Staging repeatedly went into a state where login worked but data failed to load, with `/health` returning `"database unreachable"`. It only recovered after `docker compose up -d --force-recreate api` — a plain restart/`up -d` was not enough.

## Root cause

Long idle periods on staging cause the underlying TCP connection between the API and Postgres to be silently dropped (Docker networking / NAT / conntrack). `node-postgres` only discards a client from its pool when the error is explicitly passed to `client.release(err)`. Every `withTenant()` / `pool.connect()` / `superPool.connect()` call site was calling `release()` unconditionally in its `finally` block, so the same dead connection kept being returned to the pool as "healthy" and reused by every subsequent request — causing the outage to persist indefinitely until the container was fully recreated.

## Fix

- Added `isConnectionError(err)` to `apps/api/src/db/pool.ts` to distinguish genuine connection-death errors (`ECONNRESET`, `ETIMEDOUT`, Postgres `08xxx`/`57Pxx` codes, "connection terminated", etc.) from routine SQL errors (constraint violations, etc.) that should NOT cause a healthy connection to be discarded.
- Updated `withTenant()` (`db/tenant.ts`) and the other production `pool.connect()`/`superPool.connect()` call sites (`onboarding.routes.ts` ×2, `sync.routes.ts`, `tenants.routes.ts`) to call `client.release(connectionDied)`, so a dead connection is discarded and pg-pool transparently opens a fresh one on the next request — self-healing without a container restart.
- Skip the `ROLLBACK` attempt when the connection is already dead, since it would just throw again and mask the original error.

## Validation

- `pnpm --filter @amis/api typecheck` passes
- `src/db/pool.recovery.test.ts` — 2 passed
- `src/modules/onboarding`, `src/modules/sync`, `src/modules/tenants`, `src/db` — 16 passed
- `src/modules/students`, `src/modules/fees`, `src/modules/marks` — 92 passed

No regressions observed.