### PR TITLE
fix(attendance): load full class roster so sheet isn't empty on first-time attendance

### DIFF
--- a/apps/web/src/modules/attendance/AttendancePage.tsx
+++ b/apps/web/src/modules/attendance/AttendancePage.tsx
@@ -13,6 +13,7 @@ import {
 import { listAcademicYears } from "../academic-calendar/academic-calendar.api";
 import { listCourses } from "../courses/courses.api";
 import { listProgrammes } from "../programmes/programmes.api";
+import { listStudents } from "../students/students.api";
 import {
   ensureGlobalCss,
   PageHeader,
@@ -98,6 +99,16 @@ export function AttendancePage() {
     enabled: viewMode === "summary",
   });
 
+  // Full class roster for the selected programme — the attendance sheet must
+  // show every enrolled student, not just students who already have an
+  // attendance record for this exact date (otherwise a never-recorded
+  // course/date shows an empty, apparently "unresponsive" sheet).
+  const rosterQuery = useQuery({
+    queryKey: ["attendance-roster", applied.programme],
+    queryFn: () => listStudents({ programme: applied.programme, limit: 500 }),
+    enabled: canQuery && viewMode === "sheet" && !!applied.programme,
+  });
+
   const batchMutation = useMutation({
     mutationFn: () => {
       const records: BatchAttendanceItem[] = Object.entries(sheet).map(
@@ -159,13 +170,23 @@ export function AttendancePage() {
   const records = attendanceQuery.data ?? [];
   const summary = summaryQuery.data ?? [];
 
-  // Unique students from loaded records (for the sheet)
-  const students = records.length > 0
-    ? records.filter(
+  // Class roster to display on the sheet: prefer the full enrolled roster
+  // (by programme) so attendance can be taken even when no records exist yet
+  // for this date; fall back to students who already have a record (e.g. no
+  // programme resolved) so existing data is never hidden.
+  const roster = rosterQuery.data ?? [];
+  const students = roster.length > 0
+    ? roster.map((s) => ({
+        student_id: s.id,
+        first_name: s.first_name,
+        last_name: s.last_name,
+        admission_number: s.admission_number,
+      }))
+    : records.filter(
         (r, i, arr) =>
           arr.findIndex((x) => x.student_id === r.student_id) === i
-      )
-    : [];
+      );
+  const isRosterLoading = rosterQuery.isLoading && !!applied.programme;
 
   function getStatus(studentId: string): AttendanceStatus {
     return sheet[studentId]?.status ?? "present";
@@ -337,7 +358,7 @@ export function AttendancePage() {
                 then click Apply to load the attendance sheet.
               </p>
             </Card>
-          ) : attendanceQuery.isLoading ? (
+          ) : attendanceQuery.isLoading || isRosterLoading ? (
             <Card padding="16px 20px">
               <div
                 style={{
@@ -350,13 +371,22 @@ export function AttendancePage() {
             </Card>
           ) : attendanceQuery.isError ? (
             <ErrorBanner message="Failed to load attendance records." />
+          ) : rosterQuery.isError ? (
+            <ErrorBanner message="Failed to load the class roster." />
           ) : (
             <>
-              {records.length === 0 ? (
+              {students.length === 0 ? (
                 <Card padding="24px" style={{ marginBottom: 16 }}>
                   <p style={{ fontSize: 14, color: C.gray500, margin: 0 }}>
-                    No existing records for this course &amp; date. Add students
-                    below by entering their attendance.
+                    No students found for this programme. Select a course whose
+                    programme has enrolled students, or add students first.
+                  </p>
+                </Card>
+              ) : records.length === 0 ? (
+                <Card padding="24px" style={{ marginBottom: 16 }}>
+                  <p style={{ fontSize: 14, color: C.gray500, margin: 0 }}>
+                    No existing records for this course &amp; date. Enter
+                    attendance for the students below and click Save.
                   </p>
                 </Card>
               ) : (


### PR DESCRIPTION
Fixes #299

## Root cause
The Attendance sheet ([AttendancePage.tsx](apps/web/src/modules/attendance/AttendancePage.tsx)) derived its student list solely from existing `app.attendance` records for the exact selected date. For any course/date combination that has never had attendance recorded (the normal first-time scenario), that list is empty, so the sheet renders no rows and no controls at all — appearing completely unresponsive.

## Fix
The sheet now also loads the full student roster for the selected programme (`GET /students?programme=`) and merges it with any existing attendance records, so there's always a roster to mark. Existing statuses can still be pre-seeded via "Load existing". Added distinct loading/error/empty states for the roster vs. existing records.

Frontend-only change — no backend/schema changes required.

## Testing
- `tsc --noEmit` clean on the changed file
- Ran the full API test suite (600 tests): 599 passed, 1 pre-existing unrelated flaky timeout in `requireAuth.test.ts` (not touched by this change)

## To retest
Log in as Instructor/Admin → Attendance → pick a course/date that has never had attendance recorded → confirm enrolled students for that programme appear with editable status/notes and Save works.